### PR TITLE
Remove non-existent Sonos plug and unused TV buttons

### DIFF
--- a/device_control/device_config.py
+++ b/device_control/device_config.py
@@ -15,12 +15,6 @@ floor, and room. Each device entry specifies:
 TV_DEVICES = {
     "Living Room": [
         {
-            "entity_id": "media_player.living_room_television",
-            "name": "Living Room TV",
-            "type": "media_player",
-            "icon": "fa-tv",
-        },
-        {
             "entity_id": "switch.living_room_tv_socket_1",
             "name": "TV Power Socket",
             "type": "switch",
@@ -54,20 +48,8 @@ TV_DEVICES = {
             "type": "switch",
             "icon": "fa-plug",
         },
-        {
-            "entity_id": "switch.smart_outlet_2_socket_2",
-            "name": "Sonos Arc Ultra",
-            "type": "switch",
-            "icon": "fa-plug",
-        },
     ],
     "Games Room": [
-        {
-            "entity_id": "media_player.65_the_frame",
-            "name": "Games Room TV",
-            "type": "media_player",
-            "icon": "fa-tv",
-        },
         {
             "entity_id": "switch.media_room_tv_socket_1",
             "name": "TV Power Socket",
@@ -82,12 +64,6 @@ TV_DEVICES = {
         },
     ],
     "Office": [
-        {
-            "entity_id": "media_player.office_television",
-            "name": "Office TV",
-            "type": "media_player",
-            "icon": "fa-tv",
-        },
         {
             "entity_id": "switch.office_tv_socket_1",
             "name": "TV Power Socket",

--- a/vacation_mode/steps.py
+++ b/vacation_mode/steps.py
@@ -209,14 +209,6 @@ VACATION_STEPS = [
             {
                 "action": "switch/turn_off",
                 "data": {
-                    "entity_id": "switch.smart_outlet_2_socket_2",
-                },
-                "description": "Basement Master Sonos",
-                "delay_after": 1,
-            },
-            {
-                "action": "switch/turn_off",
-                "data": {
                     "entity_id": "switch.media_room_tv_socket_1",
                 },
                 "description": "Games Room TV",
@@ -501,14 +493,6 @@ HOME_STEPS = [
                     "entity_id": "switch.basement_master_tv_socket_1",
                 },
                 "description": "Basement Master TV",
-            },
-            {
-                "action": "switch/turn_on",
-                "data": {
-                    "entity_id": "switch.smart_outlet_2_socket_2",
-                },
-                "description": "Basement Master Sonos",
-                "delay_after": 1,
             },
             {
                 "action": "switch/turn_on",


### PR DESCRIPTION
- Remove Sonos Arc Ultra plug from Basement Master (no Sonos speaker there)
- Remove TV media_player buttons from Living Room, Games Room, and Office (keep power socket plugs for all three)

All 22 device_control tests pass.