### PR TITLE
Fix snow report live test failures

### DIFF
--- a/snow_report/tests.py
+++ b/snow_report/tests.py
@@ -107,7 +107,7 @@ class LiveParseWeatherHtmlTests(TestCase):
             try:
                 temp_value = int(temp["value"])
                 self.assertGreaterEqual(temp_value, -50, f"Temperature of {temp['value']} for {temp['location']} is less than -50")
-                self.assertLessEqual(temp_value, 50, f"Temperature of {temp['value']} for {temp['location']} is greater than 50")
+                self.assertLessEqual(temp_value, 110, f"Temperature of {temp['value']} for {temp['location']} is greater than 110")
             except ValueError:
                 self.fail(f"Temperature value for {temp['location']} is not a valid integer: {temp['value']}")
 

--- a/snow_report/views.py
+++ b/snow_report/views.py
@@ -227,7 +227,8 @@ def map_weather_icon(sunpeaks_icon):
         "icon-partly_cloudy_night": "fas fa-cloud-moon",
         "icon-mainly_cloudy_night": "fas fa-cloud-moon",
         "icon-cloudy_night": "fas fa-cloud-moon",
-        "icon-snow_flurries_night": "fas fa-snowflake",        
+        "icon-snow_flurries_night": "fas fa-snowflake",
+        "icon-mixed_snow_night": "fas fa-snowflake",
     }
     
     icon = icon_mapping.get(sunpeaks_icon, "fas fa-question-circle")


### PR DESCRIPTION
## Changes

- **snow_report/tests.py**: Raised temperature upper bound assertion from 50°F to 110°F so live data tests don't fail during warmer months (season is over, Valley hit 52°F)
- **snow_report/views.py**: Added `icon-mixed_snow_night` to the weather icon mapping — Sun Peaks started returning this new icon class

Fixes the daily test failure from April 6.