### PR TITLE
Fix weather scraper selector to ignore new air quality section

### DIFF
--- a/BlackDiamondHub/views.py
+++ b/BlackDiamondHub/views.py
@@ -26,8 +26,8 @@ def landing_page(request):
     
     weather_data = []
 
-    # Find all list items under the class "list-temps"
-    list_temps = soup.select('ul.list-temps li')
+    # Find all list items under current-temps (not air-quality or other sections)
+    list_temps = soup.select('div.current-temps ul.list-temps li')
 
     # Iterate over each item and extract the relevant data
     for item in list_temps:

--- a/snow_report/tests.py
+++ b/snow_report/tests.py
@@ -119,66 +119,73 @@ class LiveParseWeatherHtmlTests(TestCase):
 
         ##########################
         ## Snow Conditions
+        ## (may be empty off-season when Sun Peaks removes the
+        ## snow-conditions section from the page)
         ##########################
         snow_conditions = weather_data_metric["snow_conditions"]
-        self.assertEqual(len(snow_conditions), 4, f"Expected 4 snow conditions but found: {len(snow_conditions)}")
+        if len(snow_conditions) > 0:
+            self.assertEqual(len(snow_conditions), 4, f"Expected 4 snow conditions but found: {len(snow_conditions)}")
 
-        for snow in snow_conditions:
-            self.assertNotEqual(snow["period"], "", f"Snow condition period for {snow['period']} is empty")
-            self.assertNotEqual(snow["value"], "", f"Snow condition value for {snow['period']} is empty")
+            for snow in snow_conditions:
+                self.assertNotEqual(snow["period"], "", f"Snow condition period for {snow['period']} is empty")
+                self.assertNotEqual(snow["value"], "", f"Snow condition value for {snow['period']} is empty")
 
-        expected_unit = "in" if units == "imperial" else "cm"
-        for snow in snow_conditions:
-            self.assertEqual(snow["unit"], expected_unit, f"Snow condition unit for {snow['period']} is {snow['unit']} - expected: {expected_unit}")
+            expected_unit = "in" if units == "imperial" else "cm"
+            for snow in snow_conditions:
+                self.assertEqual(snow["unit"], expected_unit, f"Snow condition unit for {snow['period']} is {snow['unit']} - expected: {expected_unit}")
 
         ##########################
         ## Wind Speeds
+        ## (may be empty off-season)
         ##########################
         wind_speeds = weather_data_metric["wind_speeds"]
-        self.assertEqual(len(wind_speeds), 3, f"Expected 3 wind speeds but found {len(wind_speeds)}")
+        if len(wind_speeds) > 0:
+            self.assertEqual(len(wind_speeds), 3, f"Expected 3 wind speeds but found {len(wind_speeds)}")
 
-        for wind in wind_speeds:
-            self.assertNotEqual(wind["location"], "", f"Wind speed location for {wind['location']} is empty")
-            self.assertNotEqual(wind["elevation"], "", f"Wind speed elevation for {wind['location']} is empty")
+            for wind in wind_speeds:
+                self.assertNotEqual(wind["location"], "", f"Wind speed location for {wind['location']} is empty")
+                self.assertNotEqual(wind["elevation"], "", f"Wind speed elevation for {wind['location']} is empty")
 
-            try:
-                temp_value = int(wind["elevation"])
-                self.assertGreaterEqual(temp_value, 1000, f"Elevation of {wind['elevation']} for {wind['location']} is less than 1000")
-                self.assertLessEqual(temp_value, 10000, f"Elevation of {wind['elevation']} for {wind['location']} is greater than 10000")
-            except ValueError:
-                self.fail(f"Elevation value for {wind['location']} is not a valid integer: {wind['elevation']}")
+                try:
+                    temp_value = int(wind["elevation"])
+                    self.assertGreaterEqual(temp_value, 1000, f"Elevation of {wind['elevation']} for {wind['location']} is less than 1000")
+                    self.assertLessEqual(temp_value, 10000, f"Elevation of {wind['elevation']} for {wind['location']} is greater than 10000")
+                except ValueError:
+                    self.fail(f"Elevation value for {wind['location']} is not a valid integer: {wind['elevation']}")
 
-        for wind in wind_speeds:
-            self.assertNotEqual(wind["speed_direction"], "", f"Wind speed direction for {wind['location']} is empty")
-            self.assertNotEqual(wind["speed_average"], "", f"Wind speed average for {wind['location']} is empty")
+            for wind in wind_speeds:
+                self.assertNotEqual(wind["speed_direction"], "", f"Wind speed direction for {wind['location']} is empty")
+                self.assertNotEqual(wind["speed_average"], "", f"Wind speed average for {wind['location']} is empty")
 
-            try:
-                temp_value = int(wind["speed_average"])
-                self.assertGreaterEqual(temp_value, 0, f"Wind speed of {wind['speed_average']} for {wind['location']} is less than 0")
-                self.assertLessEqual(temp_value, 150, f"Wind speed of {wind['speed_average']} for {wind['location']} is greater than 150")
-            except ValueError:
-                self.fail(f"Wind speed value for {wind['location']} is not a valid integer: {wind['speed_average']}")
+                try:
+                    temp_value = int(wind["speed_average"])
+                    self.assertGreaterEqual(temp_value, 0, f"Wind speed of {wind['speed_average']} for {wind['location']} is less than 0")
+                    self.assertLessEqual(temp_value, 150, f"Wind speed of {wind['speed_average']} for {wind['location']} is greater than 150")
+                except ValueError:
+                    self.fail(f"Wind speed value for {wind['location']} is not a valid integer: {wind['speed_average']}")
 
-        expected_unit = "mph" if units == "imperial" else "kph"
-        for wind in wind_speeds:
-            self.assertEqual(wind["speed_unit"], expected_unit, f"Wind speed unit for {wind['location']} is {wind['speed_unit']} - expected: {expected_unit}")
+            expected_unit = "mph" if units == "imperial" else "kph"
+            for wind in wind_speeds:
+                self.assertEqual(wind["speed_unit"], expected_unit, f"Wind speed unit for {wind['location']} is {wind['speed_unit']} - expected: {expected_unit}")
 
         ##########################
         ## Forecast
+        ## (may be empty off-season)
         ##########################
         forecast = weather_data_metric["forecast"]
-        self.assertEqual(len(forecast), 6, f"Expected 6 forecast items but found {len(forecast)}")
+        if len(forecast) > 0:
+            self.assertEqual(len(forecast), 6, f"Expected 6 forecast items but found {len(forecast)}")
 
-        for day in forecast:
-            self.assertNotEqual(day["day_name"], "", f"Forecast day name for {day['day_name']} is empty")
-            self.assertTrue(day["day_name"].startswith(("Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun")), f"Forecast day name for {day['day_name']} is not a valid day of the week")
-            self.assertNotEqual(day["icon"], "", f"Forecast icon for {day['day_name']} is empty")
-            self.assertNotEqual(day["icon"], "fas fa-question-circle", f"Forecast icon for {day['day_name']} is set to an unknown icon (check mapping)")
-            self.assertNotEqual(day["description"], "", f"Forecast description for {day['day_name']} is empty")
+            for day in forecast:
+                self.assertNotEqual(day["day_name"], "", f"Forecast day name for {day['day_name']} is empty")
+                self.assertTrue(day["day_name"].startswith(("Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun")), f"Forecast day name for {day['day_name']} is not a valid day of the week")
+                self.assertNotEqual(day["icon"], "", f"Forecast icon for {day['day_name']} is empty")
+                self.assertNotEqual(day["icon"], "fas fa-question-circle", f"Forecast icon for {day['day_name']} is set to an unknown icon (check mapping)")
+                self.assertNotEqual(day["description"], "", f"Forecast description for {day['day_name']} is empty")
 
-        expected_unit = "°F" if units == "imperial" else "°C"
-        for day in forecast:
-            self.assertEqual(day["temp_unit"], expected_unit, f"Forecast temp unit for {day['day_name']} is {day['temp_unit']} - expected: {expected_unit}")
+            expected_unit = "°F" if units == "imperial" else "°C"
+            for day in forecast:
+                self.assertEqual(day["temp_unit"], expected_unit, f"Forecast temp unit for {day['day_name']} is {day['temp_unit']} - expected: {expected_unit}")
 
     def test_parse_weather_html_live_data_imperial(self):
         self.parse_weather_html_live_data_and_test("imperial")

--- a/snow_report/tests.py
+++ b/snow_report/tests.py
@@ -72,13 +72,15 @@ class LiveParseWeatherHtmlTests(TestCase):
         weather_data_metric = parse_weather_html(html_content, units)
         self.assertIsNotNone(weather_data_metric)
 
-        # Ensure today_icon is mapped correctly
+        # Ensure today_icon is mapped correctly (may be empty when
+        # Sun Peaks removes the current-condition section seasonally)
         today_icon = weather_data_metric["today_icon"]
-        self.assertNotEqual(today_icon, "fas fa-question-circle", f"today_icon is set to unknown value {today_icon}")
+        if today_icon:
+            self.assertNotEqual(today_icon, "fas fa-question-circle", f"today_icon is set to unknown value {today_icon}")
 
-        # Ensure today_description is not empty
+        # today_description may be empty when the current-condition
+        # section is absent from the page (e.g. off-season)
         today_description = weather_data_metric["today_description"]
-        self.assertNotEqual(today_description, "", "today_description is empty")
 
         ##########################
         ## Temperatures
@@ -210,20 +212,30 @@ class OfflineParseWeatherHtmlTests(TestCase):
               break
               
         self.assertTrue(found, "Did not find 24 hr snow condition in the list")
-        
-        
-        
-        # # Test with metric units
 
-        # self.assertIsNotNone(weather_data_metric)
-        # self.assertNotIn('', weather_data_metric.values(), "Empty string found in metric weather data")
-        # self.assertNotIn('', [item for sublist in weather_data_metric.values() if isinstance(sublist, list) for item in sublist], "Empty string found in metric weather data list items")
+    def test_parse_weather_html_ignores_air_quality(self):
+        """Ensure the parser only returns temperature entries and ignores
+        the air-quality ul.list-temps section added to the page."""
+        file_path = os.path.join(os.path.dirname(__file__), 'tests', 'weather_current.html')
+        with open(file_path, 'r', encoding='utf-8') as file:
+            html_content = file.read()
 
-        # # Test with imperial units
-        # weather_data_imperial = parse_weather_html(html_content, "imperial")
-        # self.assertIsNotNone(weather_data_imperial)
-        # self.assertNotIn('', weather_data_imperial.values(), "Empty string found in imperial weather data")
-        # self.assertNotIn('', [item for sublist in weather_data_imperial.values() if isinstance(sublist, list) for item in sublist], "Empty string found in imperial weather data list items")
+        weather_data = parse_weather_html(html_content, "metric")
+        self.assertIsNotNone(weather_data)
+
+        temperatures = weather_data["temperatures"]
+        self.assertEqual(len(temperatures), 4,
+                         f"Expected 4 temperature entries (air quality should be excluded), got {len(temperatures)}")
+
+        expected_locations = {"Top of the World", "Mid-mountain", "Top of Morrisey", "Valley"}
+        actual_locations = {t["location"] for t in temperatures}
+        self.assertEqual(actual_locations, expected_locations,
+                         f"Unexpected locations: {actual_locations}")
+
+        # Air quality stations should NOT appear in temperatures
+        for temp in temperatures:
+            self.assertNotIn("AQHI", str(temp),
+                             f"Air quality data leaked into temperatures: {temp}")
 
 
 @tag('selenium')

--- a/snow_report/tests/weather_current.html
+++ b/snow_report/tests/weather_current.html
@@ -1,0 +1,2065 @@
+
+<!DOCTYPE html>
+<html lang="en" dir="ltr" prefix="og: https://ogp.me/ns#">
+<head>
+
+      <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+                new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+              j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+              'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+      })(window,document,'script','dataLayer','GTM-N89LP4');</script>
+    <!-- End Google Tag Manager -->
+      <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+                new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+              j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+              'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+      })(window,document,'script','dataLayer','GTM-P6XDX8TB');</script>
+    <!-- End Google Tag Manager -->
+  
+    <script id="mcjs">!function(c,h,i,m,p){m=c.createElement(h),p=c.getElementsByTagName(h)[0],m.async=1,m.src=i,p.parentNode.insertBefore(m,p)}(document,"script","https://chimpstatic.com/mcjs-connected/js/users/c28b4d537d50e31b84959a1ff/6398095c7843c484c7ca351d9.js");</script>
+
+  <meta charset="utf-8" />
+<noscript><style>form.antibot * :not(.antibot-message) { display: none !important; }</style>
+</noscript><style>/* @see https://github.com/aFarkas/lazysizes#broken-image-symbol */.js img.lazyload:not([src]) { visibility: hidden; }/* @see https://github.com/aFarkas/lazysizes#automatically-setting-the-sizes-attribute */.js img.lazyloaded[data-sizes=auto] { display: block; width: 100%; }/* Transition effect. */.js .lazyload, .js .lazyloading { opacity: 0; }.js .lazyloaded { opacity: 1; -webkit-transition: opacity 2000ms; transition: opacity 2000ms; }</style>
+<meta name="description" content="Check the Sun Peaks weather forecast with current real-time conditions, including temperature, wind speeds and air quality updates to plan your day accurately." />
+<meta property="og:site_name" content="Sun Peaks Resort" />
+<meta property="og:title" content="Weather" />
+<meta property="og:description" content="Check the Sun Peaks weather forecast with current real-time conditions, including temperature, wind speeds and air quality updates to plan your day accurately." />
+<meta name="Generator" content="Drupal 10 (https://www.drupal.org)" />
+<meta name="MobileOptimized" content="width" />
+<meta name="HandheldFriendly" content="true" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<style>div#sliding-popup, div#sliding-popup .eu-cookie-withdraw-banner, .eu-cookie-withdraw-tab {background: #0779bf} div#sliding-popup.eu-cookie-withdraw-wrapper { background: transparent; } #sliding-popup h1, #sliding-popup h2, #sliding-popup h3, #sliding-popup p, #sliding-popup label, #sliding-popup div, .eu-cookie-compliance-more-button, .eu-cookie-compliance-secondary-button, .eu-cookie-withdraw-tab { color: #ffffff;} .eu-cookie-withdraw-tab { border-color: #ffffff;}</style>
+<script type="application/ld+json">{
+    "@context": "https://schema.org",
+    "@graph": [
+        {
+            "@type": "SkiResort",
+            "@id": "https://www.sunpeaksresort.com/#organization",
+            "url": "https://www.sunpeaksresort.com/",
+            "sameAs": [
+                "https://www.facebook.com/SunPeaksResort",
+                "https://www.instagram.com/sunpeaksresort",
+                "https://www.youtube.com/user/SunPeaksResortTV",
+                "https://vimeo.com/sunpeaksresort",
+                "https://www.tripadvisor.ca/Tourism-g499150-Sun_Peaks_British_Columbia-Vacations.html"
+            ],
+            "name": "Sun Peaks Resort",
+            "description": "The official ski resort website of Sun Peaks. Interior British Columbia\u0027s largest destination ski resort, offering guests award-winning skiing, snowboarding, golf, mountain biking, lodging, dining, and more.",
+            "telephone": "+1 250 578 5474",
+            "contactPoint": {
+                "@type": "ContactPoint",
+                "telephone": "+1 250 578 5474",
+                "email": "website@sunpeaksresort.com",
+                "url": "https://www.sunpeaksresort.com/"
+            },
+            "logo": {
+                "@type": "ImageObject",
+                "url": "https://www.sunpeaksresort.com/themes/custom/sunpeaksresort/images/logo_schema.svg"
+            },
+            "image": {
+                "@type": "ImageObject",
+                "url": "https://www.sunpeaksresort.com/themes/custom/sunpeaksresort/images/share.jpg"
+            },
+            "geo": {
+                "@type": "GeoCoordinates",
+                "latitude": "50.878166449126695",
+                "longitude": "-119.90744830130636"
+            },
+            "address": {
+                "@type": "PostalAddress",
+                "streetAddress": "1280 Alpine Road",
+                "addressLocality": "Sun Peaks",
+                "addressRegion": "BC",
+                "postalCode": "V0E 5N0",
+                "addressCountry": "CA"
+            }
+        },
+        {
+            "@type": "WebPage",
+            "@id": "https://www.sunpeaksresort.com/bike-hike/weather-webcams/weather/#webpage",
+            "description": "Check the Sun Peaks weather forecast with current real-time conditions, including temperature, wind speeds and air quality updates to plan your day accurately.",
+            "publisher": {
+                "@type": "SkiResort",
+                "@id": "https://www.sunpeaksresort.com/#organization"
+            },
+            "inLanguage": "en-US"
+        },
+        {
+            "@type": "WebSite",
+            "@id": "https://www.sunpeaksresort.com/#website",
+            "name": "Sun Peaks Resort",
+            "url": "https://www.sunpeaksresort.com/",
+            "publisher": {
+                "@type": "SkiResort",
+                "@id": "https://www.sunpeaksresort.com/#organization"
+            },
+            "inLanguage": "en-US"
+        }
+    ]
+}</script>
+<script type="application/ld+json">{
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    "mainEntity": [
+        {
+            "@type": "Question",
+            "name": "Q: Is this the Sun Peaks weather forecast?",
+            "acceptedAnswer": {
+                "@type": "Answer",
+                "text": "A: Yes. This page provides the Sun Peaks weather forecast, using on-site observations and resort-specific forecasting rather than data from nearby communities."
+            }
+        },
+        {
+            "@type": "Question",
+            "name": "Q: How accurate is the Sun Peaks weather report?",
+            "acceptedAnswer": {
+                "@type": "Answer",
+                "text": "A: Conditions are measured directly on the mountain using resort weather stations, providing highly accurate, location-specific data including temperature, wind and air quality."
+            }
+        },
+        {
+            "@type": "Question",
+            "name": "Q: Does Sun Peaks have its own snow report?",
+            "acceptedAnswer": {
+                "@type": "Answer",
+                "text": "A: Yes. During the winter season, snowfall totals and snow conditions are tracked on the mountain and updated regularly."
+            }
+        }
+    ]
+}</script>
+<link rel="icon" href="/core/misc/favicon.ico" type="image/vnd.microsoft.icon" />
+<link rel="canonical" href="https://www.sunpeaksresort.com/bike-hike/weather-webcams/weather" />
+<link rel="shortlink" href="https://www.sunpeaksresort.com/node/118" />
+
+
+    <link rel="preload" as="font" href="/themes/custom/sunpeaksresort/fonts/gotham-black-webfont.woff2" type="font/woff2" crossorigin>
+    <link rel="preload" as="font" href="/themes/custom/sunpeaksresort/fonts/gotham-bold-webfont.woff2" type="font/woff2" crossorigin>
+    <link rel="preload" as="font" href="/themes/custom/sunpeaksresort/fonts/gotham-medium-webfont.woff2" type="font/woff2" crossorigin>
+    <link rel="preload" as="font" href="/themes/custom/sunpeaksresort/fonts/gotham-book-webfont.woff2" type="font/woff2" crossorigin>
+
+    <link rel="preload" href="https://cdn.jsdelivr.net/combine/npm/nanoscroller@0.8.7/bin/css/nanoscroller.min.css,npm/formstone@1.4.2/dist/css/themes/light.css,npm/formstone@1.4.18-1/dist/css/checkbox.min.css,npm/formstone@1.4.18-1/dist/css/dropdown.min.css,npm/slick-carousel@1.8.1/slick/slick.min.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
+    <link rel="preload" href="https://cdn.jsdelivr.net/combine/npm/slick-carousel@1.8.1/slick/slick-theme.min.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
+    <noscript><link rel="stylesheet" href="https://cdn.jsdelivr.net/combine/npm/slick-carousel@1.8.1/slick/slick-theme.min.css"></noscript>
+    <noscript><link rel="stylesheet" href="https://cdn.jsdelivr.net/combine/npm/slick-carousel@1.8.1/slick/slick-theme.min.css"></noscript>
+
+
+    <title>Weather | Sun Peaks Resort</title>
+
+    <link rel="stylesheet" media="all" href="/sites/default/files/css/css_1eiOeT7gStUPGPMN2-fVYf9HlBbijg3t0KFItfNdSL0.css?delta=0&amp;language=en&amp;theme=sunpeaksresort&amp;include=eJxtjzuShDAMBS_kRUdyCfMADfJnJStgT79TNQHJRK9fZ81CLPnQvrKmwuXEruEnPbhUtEhF2f2mCnc-4Kl0A7VulVX-kBC59H4J3lOHCrcC-ibzhp1DZ3r9BuzOIXnjiSHlgtGDabDxYTxOp81isC6PWaKNWFX8xJb8fcCXG7zbpE_Kj89bpR3Jb5-otLLjH3NvXLg" />
+<link rel="stylesheet" media="all" href="/sites/default/files/css/css_GyWPobDbeJnaF1_wMvZCj0ug_tmohD9eUose8mjDuxw.css?delta=1&amp;language=en&amp;theme=sunpeaksresort&amp;include=eJxtjzuShDAMBS_kRUdyCfMADfJnJStgT79TNQHJRK9fZ81CLPnQvrKmwuXEruEnPbhUtEhF2f2mCnc-4Kl0A7VulVX-kBC59H4J3lOHCrcC-ibzhp1DZ3r9BuzOIXnjiSHlgtGDabDxYTxOp81isC6PWaKNWFX8xJb8fcCXG7zbpE_Kj89bpR3Jb5-otLLjH3NvXLg" />
+
+    <script src="/core/assets/vendor/modernizr/modernizr.min.js?v=3.11.7"></script>
+
+
+
+      <link rel="icon" type="image/svg+xml" href="/themes/custom/sunpeaksresort/images/favicon/favicon.svg">
+      <link rel="apple-touch-icon" sizes="180x180" href="/themes/custom/sunpeaksresort/images/favicon/apple-touch-icon.png">
+      <link rel="icon" type="image/png" sizes="32x32" href="/themes/custom/sunpeaksresort/images/favicon/favicon-32x32.png">
+      <link rel="icon" type="image/png" sizes="16x16" href="/themes/custom/sunpeaksresort/images/favicon/favicon-16x16.png">
+      <link rel="manifest" href="/themes/custom/sunpeaksresort/images/favicon/site.webmanifest">
+      <link rel="mask-icon" href="/themes/custom/sunpeaksresort/images/favicon/safari-pinned-tab.svg" color="#1a366c">
+      <link rel="shortcut icon" href="/themes/custom/sunpeaksresort/images/favicon/favicon.ico">
+      <meta name="msapplication-TileColor" content="#ffffff">
+      <meta name="msapplication-config" content="/themes/custom/sunpeaksresort/images/favicon/browserconfig.xml">
+      <meta name="theme-color" content="#ffffff">
+
+      <meta property="fb:app_id" content="133035827351496" />
+
+      <!-- Wishpond tracking -->
+      <script type="text/javascript" src="//cdn.wishpond.net/connect.js?merchantId=1416860&writeKey=150f6d178a59" async></script>
+
+</head>
+<body class="role--anonymous path-node page-node-type-page summer section-bike-hike">
+
+      <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-N89LP4"
+                      height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
+      <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P6XDX8TB"
+                      height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
+  
+
+      
+  
+        <div class="dialog-off-canvas-main-canvas" data-off-canvas-main-canvas>
+    
+
+
+
+
+
+
+<header id="header" class="transition" >
+
+    <a href="#main" class="skip-to-content" tabindex="0">Skip to main content</a>
+
+    
+<div id="alertbar">
+
+    
+</div>
+
+
+    <div class="inner">
+
+        <div class="container">
+
+            <a href="/" rel="home" class="logo">
+                <img src="/themes/custom/sunpeaksresort/images/logo.svg?v=2" alt="Sunpeaks Resort Homepage" />
+            </a>
+
+            <div id="main-nav">
+                <nav role="navigation" aria-labelledby="block-sunpeaksresort-main-menu-menu" id="block-sunpeaksresort-main-menu" class="block block-menu navigation menu--main">
+            
+  <h2 class="visually-hidden" id="block-sunpeaksresort-main-menu-menu">Main navigation</h2>
+  
+
+        
+        <ul class="menu">
+                  <li class="menu-item menu-item-explore menu-item--collapsed">
+
+                  <a href="/explore" data-drupal-link-system-path="node/1">Explore</a>
+        
+      </li>
+                <li class="menu-item menu-item-ski--ride menu-item--collapsed">
+
+                  <a href="/ski-ride" data-drupal-link-system-path="node/2">Ski &amp; Ride</a>
+        
+      </li>
+                <li class="menu-item menu-item-bike--hike menu-item--collapsed menu-item--active-trail">
+
+                  <a href="/bike-hike" data-drupal-link-system-path="node/3">Bike &amp; Hike</a>
+        
+      </li>
+                <li class="menu-item menu-item-golf menu-item--collapsed">
+
+                  <a href="/golf-section" data-drupal-link-system-path="node/4">Golf</a>
+        
+      </li>
+                <li class="menu-item menu-item-events--things-to-do menu-item--collapsed">
+
+                  <a href="/events-things-to-do" data-drupal-link-system-path="node/5">Events &amp; Things To Do</a>
+        
+      </li>
+                <li class="menu-item menu-item-places-to-stay menu-item--collapsed">
+
+                  <a href="/places-to-stay" data-drupal-link-system-path="node/6">Places To Stay</a>
+        
+      </li>
+                <li class="menu-item menu-item-real-estate menu-item--collapsed">
+
+                  <a href="">Real Estate</a>
+        
+      </li>
+      </ul>
+    
+
+
+  </nav>
+
+            </div>
+
+            
+
+<div id="menu-overlay" class="overlay" role="dialog" >
+<div class="container">
+    <div id="menu-explore" class="sub-menu nano" aria-hidden="true">
+    <div class="nano-content">
+
+        <div class="inner">
+
+            
+            <!-- Print Menus -->
+            <nav role="navigation" aria-labelledby="block-explore-menu-menu" id="block-explore-menu" class="block block-menu navigation menu--main">
+            
+  <h2 class="visually-hidden" id="block-explore-menu-menu">Explore Menu</h2>
+  
+
+        
+        <ul class="menu">
+                  <li class="menu-item menu-item-sun-peaks-in-summer">
+
+                  <a href="/explore/sun-peaks-in-summer" data-drupal-link-system-path="node/103">Sun Peaks in Summer</a>
+        
+      </li>
+                <li class="menu-item menu-item-sun-peaks-in-winter">
+
+                  <a href="/explore/sun-peaks-in-winter" data-drupal-link-system-path="node/102">Sun Peaks in Winter</a>
+        
+      </li>
+                <li class="menu-item menu-item-stories--inspiration">
+
+                  <a href="/explore/stories-inspiration" data-drupal-link-system-path="node/28">Stories &amp; Inspiration</a>
+        
+      </li>
+                <li class="menu-item menu-item-news--updates">
+
+                  <a href="/explore/news-updates" data-drupal-link-system-path="node/30">News &amp; Updates</a>
+        
+      </li>
+                <li class="menu-item menu-item-galleries menu-item--expanded">
+
+                  <a class="title" tabindex="0">Galleries</a>
+                    <ul class="menu">
+                    <li class="menu-item menu-item-photo-gallery">
+
+                  <a href="/explore/galleries/photo-gallery" data-drupal-link-system-path="node/111">Photo Gallery</a>
+        
+      </li>
+                <li class="menu-item menu-item-video-gallery">
+
+                  <a href="/explore/galleries/video-gallery" data-drupal-link-system-path="node/192">Video Gallery</a>
+        
+      </li>
+      </ul>
+    
+        
+      </li>
+                <li class="menu-item menu-item-getting-here--around menu-item--expanded">
+
+                  <a class="title" tabindex="0">Getting Here &amp; Around</a>
+                    <ul class="menu">
+                    <li class="menu-item menu-item-getting-to-sun-peaks">
+
+                  <a href="https://www.sunpeaksresort.com/explore/getting-here" title="How to Get to Sun Peaks">Getting to Sun Peaks</a>
+        
+      </li>
+                <li class="menu-item menu-item-airport-shuttles--transfers">
+
+                  <a href="/explore/getting-here-around/airport-shuttles-transfers" title="Sun Peaks Shuttles" data-drupal-link-system-path="node/2760">Airport Shuttles &amp; Transfers</a>
+        
+      </li>
+                <li class="menu-item menu-item-in-resort-shuttle">
+
+                  <a href="/explore/getting-here-around/in-resort-shuttle" data-drupal-link-system-path="node/798">In-Resort Shuttle</a>
+        
+      </li>
+                <li class="menu-item menu-item-village-map">
+
+                  <a href="/explore/getting-here-around/village-map" data-drupal-link-system-path="node/193">Village Map</a>
+        
+      </li>
+                <li class="menu-item menu-item-parking">
+
+                  <a href="/explore/getting-here-around/parking" data-drupal-link-system-path="node/3064">Parking</a>
+        
+      </li>
+      </ul>
+    
+        
+      </li>
+                <li class="menu-item menu-item-groups--weddings menu-item--expanded">
+
+                  <a class="title" tabindex="0">Groups &amp; Weddings</a>
+                    <ul class="menu">
+                    <li class="menu-item menu-item-group-bookings menu-item--collapsed">
+
+                  <a href="/explore/groups-weddings/group-bookings" title="Group Bookings" data-drupal-link-system-path="node/107">Group Bookings</a>
+        
+      </li>
+                <li class="menu-item menu-item-school-groups">
+
+                  <a href="/explore/groups-weddings/school-groups" data-drupal-link-system-path="node/108">School Groups</a>
+        
+      </li>
+                <li class="menu-item menu-item-weddings">
+
+                  <a href="/explore/groups-weddings/weddings" data-drupal-link-system-path="node/109">Weddings</a>
+        
+      </li>
+      </ul>
+    
+        
+      </li>
+                <li class="menu-item menu-item-meetings--conferences">
+
+                  <a href="/explore/meetings-conferences" title="Meetings, Conferences &amp; Retreats" data-drupal-link-system-path="node/106">Meetings &amp; Conferences</a>
+        
+      </li>
+                <li class="menu-item menu-item-find-a-business">
+
+                  <a href="/explore/business-directory" data-drupal-link-system-path="node/54">Find A Business</a>
+        
+      </li>
+                <li class="menu-item menu-item-resort-history menu-item--expanded">
+
+                  <a href="/explore/sun-peaks-resort-history" data-drupal-link-system-path="node/958">Resort History</a>
+        
+      </li>
+      </ul>
+    
+
+
+  </nav>
+
+
+            <!-- Print Booking Links -->
+            
+
+        </div>
+
+        <a class="close" href="#">Close</a>
+
+    </div>
+    </div>
+
+    <div id="menu-ski-ride" class="sub-menu nano" aria-hidden="true">
+    <div class="nano-content">
+
+        <div class="inner">
+
+            
+            <!-- Print Menus -->
+            <nav role="navigation" aria-labelledby="block-ski-ride-menu-menu" id="block-ski-ride-menu" class="block block-menu navigation menu--main">
+            
+  <h2 class="visually-hidden" id="block-ski-ride-menu-menu">Ski &amp; Ride Menu</h2>
+  
+
+        
+        <ul class="menu">
+                  <li class="menu-item menu-item-the-mountain menu-item--expanded">
+
+                  <a class="title" tabindex="0">The Mountain</a>
+                    <ul class="menu">
+                    <li class="menu-item menu-item-trail-maps--stats menu-item--collapsed">
+
+                  <a href="/ski-ride/the-mountain/trail-maps-stats" data-drupal-link-system-path="node/120">Trail Maps &amp; Stats</a>
+        
+      </li>
+                <li class="menu-item menu-item-terrain-parks menu-item--collapsed">
+
+                  <a href="/ski-ride/the-mountain/terrain-parks" data-drupal-link-system-path="node/121">Terrain Parks</a>
+        
+      </li>
+                <li class="menu-item menu-item-race-centre menu-item--collapsed">
+
+                  <a href="/ski-ride/the-mountain/race-centre" title="Race Centre" data-drupal-link-system-path="node/124">Race Centre</a>
+        
+      </li>
+                <li class="menu-item menu-item-hours-of-operation">
+
+                  <a href="/ski-ride/the-mountain/winter-hours-of-operation" data-drupal-link-system-path="node/126">Hours of Operation</a>
+        
+      </li>
+                <li class="menu-item menu-item-lifts--trail-status">
+
+                  <a href="/ski-ride/the-mountain/lifts-trail-status" data-drupal-link-system-path="node/74">Lifts &amp; Trail Status</a>
+        
+      </li>
+      </ul>
+    
+        
+      </li>
+                <li class="menu-item menu-item-tickets--passes menu-item--expanded">
+
+                  <a class="title" tabindex="0">Tickets &amp; Passes</a>
+                    <ul class="menu">
+                    <li class="menu-item menu-item-day-tickets menu-item--collapsed">
+
+                  <a href="/ski-ride/tickets-passes/day-tickets" data-drupal-link-system-path="node/113">Day Tickets</a>
+        
+      </li>
+                <li class="menu-item menu-item-alpine-peaks-cards">
+
+                  <a href="/ski-ride/tickets-passes/alpine-peaks-cards" data-drupal-link-system-path="node/115">Alpine Peaks Cards</a>
+        
+      </li>
+                <li class="menu-item menu-item-season-passes menu-item--collapsed">
+
+                  <a href="/ski-ride/tickets-passes/season-passes" data-drupal-link-system-path="node/114">Season Passes</a>
+        
+      </li>
+                <li class="menu-item menu-item-gift-cards">
+
+                  <a href="/ski-ride/tickets-passes/sun-peaks-resort-gift-cards" data-drupal-link-system-path="node/2096">Gift Cards</a>
+        
+      </li>
+                <li class="menu-item menu-item-ikon-pass">
+
+                  <a href="/ski-ride/tickets-passes/ikon-pass" data-drupal-link-system-path="node/2962">Ikon Pass</a>
+        
+      </li>
+                <li class="menu-item menu-item-mountain-collective">
+
+                  <a href="/ski-ride/tickets-passes/mountain-collective" data-drupal-link-system-path="node/2379">Mountain Collective</a>
+        
+      </li>
+      </ul>
+    
+        
+      </li>
+                <li class="menu-item menu-item-sports-school--rentals menu-item--expanded">
+
+                  <a class="title" tabindex="0">Sports School &amp; Rentals</a>
+                    <ul class="menu">
+                    <li class="menu-item menu-item-explore-sports-school">
+
+                  <a href="/ski-ride/sports-school-rentals/explore-sports-school" data-drupal-link-system-path="node/153">Explore Sports School</a>
+        
+      </li>
+                <li class="menu-item menu-item-lessons-camps--programs menu-item--collapsed">
+
+                  <a href="/ski-ride/sports-school-rentals/lessons-camps-programs" data-drupal-link-system-path="node/38">Lessons, Camps &amp; Programs</a>
+        
+      </li>
+                <li class="menu-item menu-item-sundance-kids-centre">
+
+                  <a href="/ski-ride/sports-school-rentals/sundance-kids-centre" data-drupal-link-system-path="node/154">Sundance Kids Centre</a>
+        
+      </li>
+                <li class="menu-item menu-item-rental-equipment menu-item--collapsed">
+
+                  <a href="/ski-ride/sports-school-rentals/rental-equipment" data-drupal-link-system-path="node/128">Rental Equipment</a>
+        
+      </li>
+                <li class="menu-item menu-item-adaptive-sports">
+
+                  <a href="/ski-ride/sports-school-rentals/adaptive-sports" data-drupal-link-system-path="node/129">Adaptive Sports</a>
+        
+      </li>
+      </ul>
+    
+        
+      </li>
+                <li class="menu-item menu-item-nordic-skiing menu-item--expanded">
+
+                  <a class="title" tabindex="0">Nordic Skiing</a>
+                    <ul class="menu">
+                    <li class="menu-item menu-item-explore-nordic-skiing">
+
+                  <a href="/ski-ride/nordic-skiing/explore-nordic-skiing" data-drupal-link-system-path="node/152">Explore Nordic Skiing</a>
+        
+      </li>
+                <li class="menu-item menu-item-tickets--passes">
+
+                  <a href="/ski-ride/nordic-skiing/tickets-passes" data-drupal-link-system-path="node/157">Tickets &amp; Passes</a>
+        
+      </li>
+                <li class="menu-item menu-item-trail-maps--status">
+
+                  <a href="/ski-ride/nordic-skiing/trail-maps-status" data-drupal-link-system-path="node/158">Trail Maps &amp; Status</a>
+        
+      </li>
+                <li class="menu-item menu-item-lessons-camps--events">
+
+                  <a href="/ski-ride/nordic-skiing/lessons-camps-events" data-drupal-link-system-path="node/159">Lessons, Camps &amp; Events</a>
+        
+      </li>
+                <li class="menu-item menu-item-nordic-rentals">
+
+                  <a href="/ski-ride/nordic-skiing/nordic-rentals" data-drupal-link-system-path="node/2506">Nordic Rentals</a>
+        
+      </li>
+      </ul>
+    
+        
+      </li>
+                <li class="menu-item menu-item-updates">
+
+                  <a href="/ski-ride/updates" data-drupal-link-system-path="node/177">Updates</a>
+        
+      </li>
+                <li class="menu-item menu-item-winter-safety-risk--awareness">
+
+                  <a href="/ski-ride/winter-safety-risk-awareness" data-drupal-link-system-path="node/125">Winter Safety Risk &amp; Awareness</a>
+        
+      </li>
+      </ul>
+    
+
+
+  </nav>
+
+
+            <!-- Print Booking Links -->
+                            <div class="buttons">
+                    <a href="https://store.sunpeaksresort.com/" target="_blank" class="btn-solid">Visit Our Online Store</a>
+                </div>
+
+            
+
+        </div>
+
+        <a class="close" href="#">Close</a>
+
+    </div>
+    </div>
+
+    <div id="menu-bike-hike" class="sub-menu nano" aria-hidden="true">
+    <div class="nano-content">
+
+        <div class="inner">
+
+            
+            <!-- Print Menus -->
+            <nav role="navigation" aria-labelledby="block-bike-hike-menu-menu" id="block-bike-hike-menu" class="block block-menu navigation menu--main">
+            
+  <h2 class="visually-hidden" id="block-bike-hike-menu-menu">Bike &amp; Hike Menu</h2>
+  
+
+        
+        <ul class="menu">
+                  <li class="menu-item menu-item-bike menu-item--expanded">
+
+                  <a class="title" tabindex="0">Bike</a>
+                    <ul class="menu">
+                    <li class="menu-item menu-item-explore-biking">
+
+                  <a href="/bike-hike/bike/explore-biking" data-drupal-link-system-path="node/132">Explore Biking</a>
+        
+      </li>
+                <li class="menu-item menu-item-bike-park menu-item--collapsed">
+
+                  <a href="/bike-hike/bike/bike-park" data-drupal-link-system-path="node/36">Bike Park</a>
+        
+      </li>
+                <li class="menu-item menu-item-trail-map--status">
+
+                  <a href="/bike-hike/bike/trail-map-status" data-drupal-link-system-path="node/99">Trail Map &amp; Status</a>
+        
+      </li>
+                <li class="menu-item menu-item-pedal-access-network">
+
+                  <a href="/bike-hike/bike/pedal-access-network" data-drupal-link-system-path="node/134">Pedal-Access Network</a>
+        
+      </li>
+                <li class="menu-item menu-item-camps-lessons--tours menu-item--collapsed">
+
+                  <a href="/bike-hike/bike/camps-lessons-tours" data-drupal-link-system-path="node/42">Camps, Lessons &amp; Tours</a>
+        
+      </li>
+                <li class="menu-item menu-item-rentals--gear menu-item--collapsed">
+
+                  <a href="/bike-hike/bike/rentals-gear" data-drupal-link-system-path="node/135">Rentals &amp; Gear</a>
+        
+      </li>
+      </ul>
+    
+        
+      </li>
+                <li class="menu-item menu-item-hike menu-item--expanded">
+
+                  <a class="title" tabindex="0">Hike</a>
+                    <ul class="menu">
+                    <li class="menu-item menu-item-explore-hiking">
+
+                  <a href="/bike-hike/hike/explore-hiking" data-drupal-link-system-path="node/136">Explore Hiking</a>
+        
+      </li>
+                <li class="menu-item menu-item-trail-map--status">
+
+                  <a href="/bike-hike/hike/trail-map-status" data-drupal-link-system-path="node/138">Trail Map &amp; Status</a>
+        
+      </li>
+                <li class="menu-item menu-item-guided-hiking-tours">
+
+                  <a href="/bike-hike/hike/guided-hiking-tours" data-drupal-link-system-path="node/137">Guided Hiking Tours</a>
+        
+      </li>
+                <li class="menu-item menu-item-flora--fauna">
+
+                  <a href="/bike-hike/hike/flora-fauna" data-drupal-link-system-path="node/139">Flora &amp; Fauna</a>
+        
+      </li>
+      </ul>
+    
+        
+      </li>
+                <li class="menu-item menu-item-alpine-sightseeing">
+
+                  <a href="/bike-hike/alpine-sightseeing" data-drupal-link-system-path="node/131">Alpine Sightseeing</a>
+        
+      </li>
+                <li class="menu-item menu-item-weather--webcams menu-item--expanded menu-item--active-trail">
+
+                  <a class="title" tabindex="0">Weather &amp; Webcams</a>
+                    <ul class="menu">
+                    <li class="menu-item menu-item-weather menu-item--active-trail">
+
+                  <a href="/bike-hike/weather-webcams/weather" data-drupal-link-system-path="node/118" class="is-active" aria-current="page">Weather</a>
+        
+      </li>
+                <li class="menu-item menu-item-webcams">
+
+                  <a href="/bike-hike/weather-webcams/webcams" data-drupal-link-system-path="node/119">Webcams</a>
+        
+      </li>
+      </ul>
+    
+        
+      </li>
+                <li class="menu-item menu-item-tickets--passes menu-item--expanded">
+
+                  <a class="title" tabindex="0">Tickets &amp; Passes</a>
+                    <ul class="menu">
+                    <li class="menu-item menu-item-bike-park-day-tickets">
+
+                  <a href="/bike-hike/tickets-passes/bike-park-day-tickets" data-drupal-link-system-path="node/3180">Bike Park Day Tickets</a>
+        
+      </li>
+                <li class="menu-item menu-item-bike-park-peaks-cards">
+
+                  <a href="/bike-hike/tickets-passes/bike-park-peaks-cards" data-drupal-link-system-path="node/3181">Bike Park Peaks Cards</a>
+        
+      </li>
+                <li class="menu-item menu-item-bike-park-season-passes menu-item--collapsed">
+
+                  <a href="/bike-hike/tickets-passes/bike-park-season-passes" data-drupal-link-system-path="node/1879">Bike Park Season Passes</a>
+        
+      </li>
+                <li class="menu-item menu-item-hiking--sightseeing">
+
+                  <a href="/bike-hike/tickets-passes/hikingsightseeing-tickets-passes" data-drupal-link-system-path="node/1880">Hiking &amp; Sightseeing</a>
+        
+      </li>
+      </ul>
+    
+        
+      </li>
+                <li class="menu-item menu-item-hours-of-operation">
+
+                  <a href="/bike-hike/summer-hours-of-operation" data-drupal-link-system-path="node/1100">Hours of Operation</a>
+        
+      </li>
+                <li class="menu-item menu-item-summer-safety--risk-awareness">
+
+                  <a href="/bike-hike/summer-safety-risk-awareness" data-drupal-link-system-path="node/197">Summer Safety &amp; Risk Awareness</a>
+        
+      </li>
+      </ul>
+    
+
+
+  </nav>
+
+
+            <!-- Print Booking Links -->
+                            <div class="buttons">
+                    <a href="https://store.sunpeaksresort.com/" target="_blank" class="btn-solid">Visit Our Online Store</a>
+                </div>
+
+            
+
+        </div>
+
+        <a class="close" href="#">Close</a>
+
+    </div>
+    </div>
+
+    <div id="menu-golf" class="sub-menu nano" aria-hidden="true">
+    <div class="nano-content">
+
+        <div class="inner">
+
+            
+            <!-- Print Menus -->
+            <nav role="navigation" aria-labelledby="block-golf-menu-menu" id="block-golf-menu" class="block block-menu navigation menu--main">
+            
+  <h2 class="visually-hidden" id="block-golf-menu-menu">Golf Menu</h2>
+  
+
+        
+        <ul class="menu">
+                  <li class="menu-item menu-item-explore-golf">
+
+                  <a href="/golf/explore-golf" data-drupal-link-system-path="node/140">Explore Golf</a>
+        
+      </li>
+                <li class="menu-item menu-item-rates--specials">
+
+                  <a href="/golf/rates-specials" data-drupal-link-system-path="node/141">Rates &amp; Specials</a>
+        
+      </li>
+                <li class="menu-item menu-item-memberships">
+
+                  <a href="/golf/memberships" title="Memberships" data-drupal-link-system-path="node/3631">Memberships</a>
+        
+      </li>
+                <li class="menu-item menu-item-course-info">
+
+                  <a href="/golf/course-information" data-drupal-link-system-path="node/34">Course Info</a>
+        
+      </li>
+                <li class="menu-item menu-item-course-pro-tips">
+
+                  <a href="/golf/course-pro-tips" data-drupal-link-system-path="node/142">Course Pro Tips</a>
+        
+      </li>
+                <li class="menu-item menu-item-lessons">
+
+                  <a href="/golf/lessons" data-drupal-link-system-path="node/44">Lessons</a>
+        
+      </li>
+                <li class="menu-item menu-item-groups--tournaments">
+
+                  <a href="/golf/groups-tournaments" data-drupal-link-system-path="node/143">Groups &amp; Tournaments</a>
+        
+      </li>
+                <li class="menu-item menu-item-terms--conditions">
+
+                  <a href="/golf/golf-course-terms-and-conditions" data-drupal-link-system-path="node/4464">Terms &amp; Conditions</a>
+        
+      </li>
+      </ul>
+    
+
+
+  </nav>
+
+
+            <!-- Print Booking Links -->
+                            <!--
+                <div class="buttons">
+                    <a href="/golf/rates-membership" class="btn-solid">Book A Tee Time</a> <br />
+                    <a href="https://sunpeaksresort.ltibooking.com/categories/2020-golf-memberships" class="btn-solid" target="_blank">Buy Memberships</a>
+                </div>-->
+
+            
+
+        </div>
+
+        <a class="close" href="#">Close</a>
+
+    </div>
+    </div>
+
+    <div id="menu-events-things-to-do" class="sub-menu nano" aria-hidden="true">
+    <div class="nano-content">
+
+        <div class="inner">
+
+                            <nav id="block-events-extra-menu">
+                    <ul class="menu">
+                                                    <li class="menu-item"><a href="/events-things-to-do/activities?season=summer">Summer Activities</a></li>
+                            <li class="menu-item"><a href="/events-things-to-do/activities?season=winter">Winter Activities</a></li>
+                                            </ul>
+                </nav>
+            
+            <!-- Print Menus -->
+            <nav role="navigation" aria-labelledby="block-events-menu-menu" id="block-events-menu" class="block block-menu navigation menu--main">
+            
+  <h2 class="visually-hidden" id="block-events-menu-menu">Events Menu</h2>
+  
+
+        
+        <ul class="menu">
+                  <li class="menu-item menu-item-events">
+
+                  <a href="/events-things-to-do/events" data-drupal-link-system-path="node/69">Events</a>
+        
+      </li>
+                <li class="menu-item menu-item-activities">
+
+                  <a href="/events-things-to-do/sun-peaks-activities" data-drupal-link-system-path="node/22">Activities</a>
+        
+      </li>
+                <li class="menu-item menu-item-dining--aprs">
+
+                  <a href="/events-things-to-do/dining-apres" data-drupal-link-system-path="node/46">Dining &amp; Après</a>
+        
+      </li>
+                <li class="menu-item menu-item-shopping--markets">
+
+                  <a href="/events-things-to-do/shopping-and-markets" data-drupal-link-system-path="node/47">Shopping &amp; Markets</a>
+        
+      </li>
+                <li class="menu-item menu-item-spa--wellness">
+
+                  <a href="/events-things-to-do/spa-wellness" data-drupal-link-system-path="node/48">Spa &amp; Wellness</a>
+        
+      </li>
+                <li class="menu-item menu-item-food--drink-scene">
+
+                  <a href="/events-things-to-do/food-drink-scene" data-drupal-link-system-path="node/4994">Food &amp; Drink Scene</a>
+        
+      </li>
+      </ul>
+    
+
+
+  </nav>
+
+
+            <!-- Print Booking Links -->
+            
+
+        </div>
+
+        <a class="close" href="#">Close</a>
+
+    </div>
+    </div>
+
+    <div id="menu-places-to-stay" class="sub-menu nano" aria-hidden="true">
+    <div class="nano-content">
+
+        <div class="inner">
+
+            
+            <!-- Print Menus -->
+            <nav role="navigation" aria-labelledby="block-places-to-stay-menu-menu" id="block-places-to-stay-menu" class="block block-menu navigation menu--main">
+            
+  <h2 class="visually-hidden" id="block-places-to-stay-menu-menu">Places To Stay Menu</h2>
+  
+
+        
+        <ul class="menu">
+                  <li class="menu-item menu-item-summer-accommodation-deals">
+
+                  <a href="/places-to-stay/summer-deals" data-drupal-link-system-path="node/68">Summer Accommodation Deals</a>
+        
+      </li>
+                <li class="menu-item menu-item-village-centre-hotels">
+
+                  <a href="/village-centre-hotels" data-drupal-link-system-path="node/49">Village Centre Hotels</a>
+        
+      </li>
+                <li class="menu-item menu-item-vacation-homes--condos">
+
+                  <a href="/vacation-homes-condos" data-drupal-link-system-path="node/3517">Vacation Homes &amp; Condos</a>
+        
+      </li>
+                <li class="menu-item menu-item-rving--camping">
+
+                  <a href="/places-to-stay/rving-camping" data-drupal-link-system-path="node/53">RVing &amp; Camping</a>
+        
+      </li>
+      </ul>
+    
+
+
+  </nav>
+
+
+            <!-- Print Booking Links -->
+                            <div class="buttons">
+                    <a href="/places-to-stay" class="btn-solid">Book Lodging</a>
+                </div>
+
+            
+
+        </div>
+
+        <a class="close" href="#">Close</a>
+
+    </div>
+    </div>
+
+    <div id="menu-real-estate" class="sub-menu nano" aria-hidden="true">
+    <div class="nano-content">
+
+        <div class="inner">
+
+            
+            <!-- Print Menus -->
+            <nav role="navigation" aria-labelledby="block-real-estate-menu-menu" id="block-real-estate-menu" class="block block-menu navigation menu--main">
+            
+  <h2 class="visually-hidden" id="block-real-estate-menu-menu">Real Estate Menu</h2>
+  
+
+        
+        <ul class="menu">
+                  <li class="menu-item menu-item-overview">
+
+                  <a href="/real-estate/real-estate" data-drupal-link-system-path="node/14">Overview</a>
+        
+      </li>
+                <li class="menu-item menu-item-new--recent-projects menu-item--collapsed">
+
+                  <a href="/real-estate/new-recent-projects" data-drupal-link-system-path="node/707">New &amp; Recent Projects</a>
+        
+      </li>
+                <li class="menu-item menu-item-master-development-plan menu-item--collapsed">
+
+                  <a href="/real-estate/master-development-plan" title="Master Development Plan" data-drupal-link-system-path="node/184">Master Development Plan</a>
+        
+      </li>
+                <li class="menu-item menu-item-real-estate-agencies">
+
+                  <a href="/real-estate/real-estate-agencies" data-drupal-link-system-path="node/2796">Real Estate Agencies</a>
+        
+      </li>
+      </ul>
+    
+
+
+  </nav>
+
+
+            <!-- Print Booking Links -->
+            
+
+        </div>
+
+        <a class="close" href="#">Close</a>
+
+    </div>
+    </div>
+
+</div>
+</div>
+
+            <div class="utility">
+
+                
+
+
+                <a href="#" class="toggle-btn search" data-type="search"><span>Search</span></a>
+
+                <a href="#" class="toggle-btn weather summer spring" data-type="weather">
+                    <span class="visually-hidden">Current Conditions:</span>
+                    
+
+<span class="icon icon-mainly_cloudy"></span>
+<span class="temp">
+
+    <span class="mid">
+                    5
+            </span>
+
+    <span class="valley">
+                    9
+            </span>
+
+</span>
+
+                    <span class="degree">&deg;C</span>
+                </a>
+
+                <div id="nav-toggle">
+                    <a href="#" tabindex="-1"><span class="visually-hidden"></span> </a>
+                </div>
+
+            </div>
+
+        </div>
+
+    </div>
+
+</header>
+
+<div id="page" role="document" class="">
+
+        <div id="background" class="summer">
+        <div class="foreground">
+            
+
+
+
+
+            <div class="field field--name-field-main-image field--type-entity-reference field--label-hidden field__item">
+
+<article class="media media--type-image media--view-mode-not-lazy">
+
+    
+
+    
+                    
+
+
+
+
+            <div class="field field--name-field-media-image field--type-image field--label-hidden field__item">    <img loading="eager" srcset="/sites/default/files/styles/320/public/2025-09/220304-sunpeaks-mie-4544.jpg?itok=r2EwfYvV 320w, /sites/default/files/styles/480/public/2025-09/220304-sunpeaks-mie-4544.jpg?itok=L9dHENvf 480w, /sites/default/files/styles/600/public/2025-09/220304-sunpeaks-mie-4544.jpg?itok=MovJxcF3 600w, /sites/default/files/styles/640/public/2025-09/220304-sunpeaks-mie-4544.jpg?itok=b3kFvSx3 640w, /sites/default/files/styles/768/public/2025-09/220304-sunpeaks-mie-4544.jpg?itok=TaqqJ_Sr 768w, /sites/default/files/styles/960/public/2025-09/220304-sunpeaks-mie-4544.jpg?itok=jrp2F9e1 960w, /sites/default/files/styles/1024/public/2025-09/220304-sunpeaks-mie-4544.jpg?itok=a5Unsa1j 1024w, /sites/default/files/styles/1200/public/2025-09/220304-sunpeaks-mie-4544.jpg?itok=DeqiVrEp 1200w, /sites/default/files/styles/1536/public/2025-09/220304-sunpeaks-mie-4544.jpg?itok=8Y3mK9uY 1536w, /sites/default/files/styles/1600/public/2025-09/220304-sunpeaks-mie-4544.jpg?itok=1RnLH6kK 1600w, /sites/default/files/styles/2048/public/2025-09/220304-sunpeaks-mie-4544.jpg?itok=zfAnf-1R 2048w, /sites/default/files/styles/3200/public/2025-09/220304-sunpeaks-mie-4544.jpg?itok=xC5H2xy3 3200w, /sites/default/files/styles/4500/public/2025-09/220304-sunpeaks-mie-4544.jpg?itok=RTxvYFwr 4000w" sizes="auto" width="4000" height="2667" data-x="71" data-y="38.995125609299" data-parent-fit="cover" data-aspectratio="1.4998125234346" src="/sites/default/files/styles/1536/public/2025-09/220304-sunpeaks-mie-4544.jpg?itok=8Y3mK9uY" alt="Skier descending a snowy slope under a clear blue sky at Sunpeaks Resort" />
+
+
+</div>
+      
+        
+
+    
+</article>
+</div>
+      
+        </div>
+    </div>
+    
+            <header id="page-title">
+            <h1><span class="field field--name-title field--type-string field--label-hidden">Weather</span>
+</h1>
+        </header>
+    
+    <div id="main-wrap" class="clearfix">
+
+        <main id="main"  role="main">
+
+            <section id="content">
+
+                
+                  <div class="">
+    <div data-drupal-messages-fallback class="hidden"></div>
+
+
+<div id="block-sunpeaksresort-content" class="block block-system block-system-main-block">
+  
+    
+      
+
+
+<article id="node-118"  data-history-node-id="118" class="node node-view-full node-type-page" >
+
+    <!-- Thankyou message for weather alerts signup -->
+    
+    <!-- Thankyou message for newsletter signup -->
+    
+    
+    
+
+        
+
+        
+
+        
+
+
+        <!-- Lodging Widget -->
+        
+
+        
+
+        
+
+        
+
+        
+            
+                
+
+
+
+
+            <div class="clearfix text-formatted field field--name-body field--type-text-with-summary field--label-hidden field__item"><h2>Real-time Weather Conditions at Sun Peaks</h2><p>Check the Sun Peaks weather forecast with current real-time conditions, including temperature, wind speeds and air quality updates to plan your day accurately.</p></div>
+      
+
+            
+        
+
+        
+
+        
+        
+
+        
+
+                
+
+
+                
+
+                
+                        
+
+        
+
+        
+
+        
+
+
+        
+
+
+        
+
+
+        
+
+
+        
+
+
+        
+
+
+        
+
+
+        
+
+
+        
+
+
+        
+            
+<div class="weather current-conditions">
+
+    <div class="wrapper">
+
+        <a class="converter" data-unit="metric" href="#">
+            <span class="metric">&deg;C/cm/kph</span>
+            <span class="imperial">&deg;F/in/mph</span>
+        </a>
+
+        <h2 class="line"><span>
+                                    Temperatures and Air Quality Readings
+                            </span></h2>
+
+        <div class="row weather-cols">
+
+                        
+            <div class="half current-temps">
+                <ul class="list-temps">
+                    <li>
+                        <div class="cell">
+                            <h3>Top of the World</h3>
+                            <p>Elevation: <span class="value_switch value_m">2,080</span><span class="unit_switch unit_m">m</span></p>
+                        </div>
+                        <div class="cell">
+                            <div class="weather-value top-temp">
+                                <span class="value_switch value_deg">
+                                                                            4
+                                                                    </span></div>
+                            <div class="weather-unit">&deg;<span class="unit_switch unit_deg">C</span></div>
+                        </div>
+                    </li>
+                    <li>
+                        <div class="cell">
+                            <h3>Mid-mountain</h3>
+                            <p>Elevation: <span class="value_switch value_m">1,855</span><span class="unit_switch unit_m">m</span></p>
+                        </div>
+                        <div class="cell">
+                            <div class="weather-value mid-mountain-temp">
+                                <span class="value_switch value_deg">
+                                                                            5
+                                                                    </span></div>
+                            <div class="weather-unit">&deg;<span class="unit_switch unit_deg">C</span></div>
+                        </div>
+                    </li>
+                    <li>
+                        <div class="cell">
+                            <h3>Top of Morrisey</h3>
+                            <p>Elevation: <span class="value_switch value_m">1,675</span><span class="unit_switch unit_m">m</span></p>
+                        </div>
+                        <div class="cell">
+                            <div class="weather-value">
+                                <span class="value_switch value_deg">
+                                                                            10
+                                                                    </span></div>
+                            <div class="weather-unit">&deg;<span class="unit_switch unit_deg">C</span></div>
+                        </div>
+                    </li>
+                    <li>
+                        <div class="cell">
+                            <h3>Valley</h3>
+                            <p>Elevation: <span class="value_switch value_m">1,255</span><span class="unit_switch unit_m">m</span></p>
+                        </div>
+                        <div class="cell">
+                            <div class="weather-value valley-temp">
+                                <span class="value_switch value_deg">
+                                                                            9
+                                                                    </span></div>
+                            <div class="weather-unit">&deg;<span class="unit_switch unit_deg">C</span></div>
+                        </div>
+                    </li>
+                </ul>
+            </div>
+
+                            <div class="half air-quality">
+                    <ul class="list-temps">
+                        <li>
+                            <div class="cell">
+                                <h3>Top of Sunburst</h3>
+                                <p>Elevation: <span class="value_switch value_m">1,850</span><span class="unit_switch unit_m">m</span></p>
+                            </div>
+                            <div class="cell">
+                                <div class="weather-value">
+                            <span>
+                                 1
+                            </span>
+                                </div>
+                                <div class="weather-unit">
+                                    AQHI
+                                </div>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="cell">
+                                <h3>Top of Sundance</h3>
+                                <p>Elevation: <span class="value_switch value_m">1,730</span><span class="unit_switch unit_m">m</span></p>
+                            </div>
+                            <div class="cell">
+                                <div class="weather-value">
+                            <span>
+                                 1
+                            </span>
+                                </div>
+                                <div class="weather-unit">
+                                    AQHI
+                                </div>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="cell">
+                                <h3>Top of Morrisey</h3>
+                                <p>Elevation: <span class="value_switch value_m">1,675</span><span class="unit_switch unit_m">m</span></p>
+                            </div>
+                            <div class="cell">
+                                <div class="weather-value">
+                            <span>
+                                 1
+                            </span>
+                                </div>
+                                <div class="weather-unit">
+                                    AQHI
+                                </div>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="cell">
+                                <h3>Valley</h3>
+                                <p>Elevation: <span class="value_switch value_m">1,255</span><span class="unit_switch unit_m">m</span></p>
+                            </div>
+                            <div class="cell">
+                                <div class="weather-value">
+                            <span>
+                                 1
+                            </span>
+                                </div>
+                                <div class="weather-unit">
+                                    AQHI
+                                </div>
+                            </div>
+                        </li>
+                    </ul>
+                </div>
+            
+        </div>
+
+    </div>
+
+</div>
+
+
+
+
+
+
+<!-- Sign up -->
+<div id="newsletter-signup" class="weather">
+
+    <div class="wrapper">
+
+        <h3>Newsletter Sign Up</h3>
+        <p>Get the latest resort weather and conditions, right to your inbox.</p>
+        <div id="newsletter">
+            <div class="inner">
+
+                <a href="/newsletter?referrer=weather" class="btn-solid">Sign Me Up</a>
+
+            </div>
+        </div>
+
+    </div>
+
+</div>
+
+
+
+
+<!-- Wind Speeds -->
+<div id="wind-speeds" class="weather">
+
+    <div class="wrapper">
+
+        <h2 class="line"><span>Wind Speeds</span></h2>
+        <div class="wind">
+            <div class="third">
+                <h3>Top of the World</h3>
+                <p>Elevation: <span class="value_switch value_m">2,080</span><span class="unit_switch unit_m">m</span></p>
+            </div>
+            <div class="third">
+                <h4>Direction</h4>
+                <div class="center-floats">
+                    <div class="inner">
+                        <div class="weather-value">SSE</div>
+                    </div>
+                </div>
+            </div>
+            <div class="third">
+                <h4>Average</h4>
+                <div class="center-floats">
+                    <div class="inner">
+                        <div class="weather-value"><span class="value_switch value_kph">16</span></div>
+                        <div class="weather-unit"><span class="unit_switch unit_kph">kph</span></div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="wind">
+            <div class="third">
+                <h3>Sunburst Express, Tower 18</h3>
+                <p>Elevation: <span class="value_switch value_m">1,715</span><span class="unit_switch unit_m">m</span></p>
+            </div>
+            <div class="third">
+                <h4>Direction</h4>
+                <div class="center-floats">
+                    <div class="inner">
+                        <div class="weather-value">SSE</div>
+                    </div>
+                </div>
+            </div>
+            <div class="third">
+                <h4>Average</h4>
+                <div class="center-floats">
+                    <div class="inner">
+                        <div class="weather-value"><span class="value_switch value_kph">10</span></div>
+                        <div class="weather-unit"><span class="unit_switch unit_kph">kph</span></div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        
+        <div class="wind">
+            <div class="third">
+                <h3>Morrisey Express, Tower 10</h3>
+                <p>Elevation: <span class="value_switch value_m">1,494</span><span class="unit_switch unit_m">m</span></p>
+            </div>
+            <div class="third">
+                <h4>Direction</h4>
+                <div class="center-floats">
+                    <div class="inner">
+                        <div class="weather-value">NNW</div>
+                    </div>
+                </div>
+            </div>
+            <div class="third">
+                <h4>Average</h4>
+                <div class="center-floats">
+                    <div class="inner">
+                        <div class="weather-value"><span class="value_switch value_kph">8</span></div>
+                        <div class="weather-unit"><span class="unit_switch unit_kph">kph</span></div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+    </div>
+
+</div>
+
+
+
+<!-- LINK OUT BUTTONS -->
+<div id="weather-buttons" class="weather">
+
+    
+        <a href="/bike-hike/weather-webcams/webcams" class="btn blue">View Our Webcams</a>
+        
+    
+</div>
+
+
+
+<!-- 5 Day Forecast -->
+
+<span class="lifts-open" style="display:none">
+            0
+    </span>
+<span class="trails-open" style="display:none">
+            0
+    </span>
+
+        
+
+        
+
+        
+
+        
+
+        
+
+                        <div class="padding-content faqs">
+                                                                <h2>
+                Weather &amp; Conditions FAQS
+            </h2>
+
+                                            <div class="margin-b-1 faq-item">
+                    <h3>Q: Is this the Sun Peaks weather forecast?</h3>
+                    <p>A: Yes. This page provides the Sun Peaks weather forecast, using on-site observations and resort-specific forecasting rather than data from nearby communities.</p>
+                </div>
+
+                                            <div class="margin-b-1 faq-item">
+                    <h3>Q: How accurate is the Sun Peaks weather report?</h3>
+                    <p>A: Conditions are measured directly on the mountain using resort weather stations, providing highly accurate, location-specific data including temperature, wind and air quality.</p>
+                </div>
+
+                                            <div class="margin-b-1 faq-item">
+                    <h3>Q: Does Sun Peaks have its own snow report?</h3>
+                    <p>A: Yes. During the winter season, snowfall totals and snow conditions are tracked on the mountain and updated regularly.</p>
+                </div>
+
+                    </div>
+    
+
+    <!-- end if front -->
+    
+
+
+    
+</article>
+
+
+  </div>
+  </div>
+
+
+            </section>
+
+            <a class="to-top" href="#">Top</a>
+
+        </main>
+
+
+        
+            <aside id="sidebar">
+
+                <nav role="navigation" aria-labelledby="block-secondarynavigation-menu" id="block-secondarynavigation" class="block block-menu navigation menu--main">
+            
+  <h2 class="visually-hidden" id="block-secondarynavigation-menu">Secondary Navigation</h2>
+  
+
+        
+        <ul class="menu">
+                  <li class="menu-item menu-item-bike menu-item--expanded">
+
+                  <a class="title" tabindex="0">Bike</a>
+                    <ul class="menu">
+                    <li class="menu-item menu-item-explore-biking">
+
+                  <a href="/bike-hike/bike/explore-biking" data-drupal-link-system-path="node/132">Explore Biking</a>
+        
+      </li>
+                <li class="menu-item menu-item-bike-park menu-item--collapsed">
+
+                  <a href="/bike-hike/bike/bike-park" data-drupal-link-system-path="node/36">Bike Park</a>
+        
+      </li>
+                <li class="menu-item menu-item-trail-map--status">
+
+                  <a href="/bike-hike/bike/trail-map-status" data-drupal-link-system-path="node/99">Trail Map &amp; Status</a>
+        
+      </li>
+                <li class="menu-item menu-item-pedal-access-network">
+
+                  <a href="/bike-hike/bike/pedal-access-network" data-drupal-link-system-path="node/134">Pedal-Access Network</a>
+        
+      </li>
+                <li class="menu-item menu-item-camps-lessons--tours menu-item--collapsed">
+
+                  <a href="/bike-hike/bike/camps-lessons-tours" data-drupal-link-system-path="node/42">Camps, Lessons &amp; Tours</a>
+        
+      </li>
+                <li class="menu-item menu-item-rentals--gear menu-item--collapsed">
+
+                  <a href="/bike-hike/bike/rentals-gear" data-drupal-link-system-path="node/135">Rentals &amp; Gear</a>
+        
+      </li>
+      </ul>
+    
+        
+      </li>
+                <li class="menu-item menu-item-hike menu-item--expanded">
+
+                  <a class="title" tabindex="0">Hike</a>
+                    <ul class="menu">
+                    <li class="menu-item menu-item-explore-hiking">
+
+                  <a href="/bike-hike/hike/explore-hiking" data-drupal-link-system-path="node/136">Explore Hiking</a>
+        
+      </li>
+                <li class="menu-item menu-item-trail-map--status">
+
+                  <a href="/bike-hike/hike/trail-map-status" data-drupal-link-system-path="node/138">Trail Map &amp; Status</a>
+        
+      </li>
+                <li class="menu-item menu-item-guided-hiking-tours">
+
+                  <a href="/bike-hike/hike/guided-hiking-tours" data-drupal-link-system-path="node/137">Guided Hiking Tours</a>
+        
+      </li>
+                <li class="menu-item menu-item-flora--fauna">
+
+                  <a href="/bike-hike/hike/flora-fauna" data-drupal-link-system-path="node/139">Flora &amp; Fauna</a>
+        
+      </li>
+      </ul>
+    
+        
+      </li>
+                <li class="menu-item menu-item-alpine-sightseeing">
+
+                  <a href="/bike-hike/alpine-sightseeing" data-drupal-link-system-path="node/131">Alpine Sightseeing</a>
+        
+      </li>
+                <li class="menu-item menu-item-weather--webcams menu-item--expanded menu-item--active-trail">
+
+                  <a class="title" tabindex="0">Weather &amp; Webcams</a>
+                    <ul class="menu">
+                    <li class="menu-item menu-item-weather menu-item--active-trail">
+
+                  <a href="/bike-hike/weather-webcams/weather" data-drupal-link-system-path="node/118" class="is-active" aria-current="page">Weather</a>
+        
+      </li>
+                <li class="menu-item menu-item-webcams">
+
+                  <a href="/bike-hike/weather-webcams/webcams" data-drupal-link-system-path="node/119">Webcams</a>
+        
+      </li>
+      </ul>
+    
+        
+      </li>
+                <li class="menu-item menu-item-tickets--passes menu-item--expanded">
+
+                  <a class="title" tabindex="0">Tickets &amp; Passes</a>
+                    <ul class="menu">
+                    <li class="menu-item menu-item-bike-park-day-tickets">
+
+                  <a href="/bike-hike/tickets-passes/bike-park-day-tickets" data-drupal-link-system-path="node/3180">Bike Park Day Tickets</a>
+        
+      </li>
+                <li class="menu-item menu-item-bike-park-peaks-cards">
+
+                  <a href="/bike-hike/tickets-passes/bike-park-peaks-cards" data-drupal-link-system-path="node/3181">Bike Park Peaks Cards</a>
+        
+      </li>
+                <li class="menu-item menu-item-bike-park-season-passes menu-item--collapsed">
+
+                  <a href="/bike-hike/tickets-passes/bike-park-season-passes" data-drupal-link-system-path="node/1879">Bike Park Season Passes</a>
+        
+      </li>
+                <li class="menu-item menu-item-hiking--sightseeing">
+
+                  <a href="/bike-hike/tickets-passes/hikingsightseeing-tickets-passes" data-drupal-link-system-path="node/1880">Hiking &amp; Sightseeing</a>
+        
+      </li>
+      </ul>
+    
+        
+      </li>
+                <li class="menu-item menu-item-hours-of-operation">
+
+                  <a href="/bike-hike/summer-hours-of-operation" data-drupal-link-system-path="node/1100">Hours of Operation</a>
+        
+      </li>
+                <li class="menu-item menu-item-summer-safety--risk-awareness">
+
+                  <a href="/bike-hike/summer-safety-risk-awareness" data-drupal-link-system-path="node/197">Summer Safety &amp; Risk Awareness</a>
+        
+      </li>
+      </ul>
+    
+
+
+  </nav>
+
+                
+                
+
+                                    
+<div id="tickets" class="cta">
+    <div class="inner">
+
+        <h3>Online Tickets</h3>
+
+        <p>Secure your ticket! Buy online in advance.</p>
+
+        <footer>
+            <p><a href="https://store.sunpeaksresort.com/" target="_blank" class="btn-solid visit-our-store-118">Buy Now</a></p>
+        </footer>
+
+    </div>
+</div>
+                
+            </aside>
+
+        
+    </div>
+
+</div>
+
+
+
+<footer id="footer" role="contentinfo">
+
+    <section class="shin">
+        <div class="container">
+                            <nav role="navigation" aria-labelledby="block-corporatemenu-menu" id="block-corporatemenu" class="block block-menu navigation menu--corporate-menu">
+            
+  <h2 class="visually-hidden" id="block-corporatemenu-menu">Corporate Menu</h2>
+  
+
+        
+        <ul class="menu">
+                  <li class="menu-item menu-item-getting-to-sun-peaks">
+
+                  <a href="https://www.sunpeaksresort.com/explore/how-to-get-to-sun-peaks">Getting to Sun Peaks</a>
+        
+      </li>
+                <li class="menu-item menu-item-media menu-item--collapsed">
+
+                  <a href="/media-centre" data-drupal-link-system-path="node/11">Media</a>
+        
+      </li>
+                <li class="menu-item menu-item-travel-trade">
+
+                  <a href="/travel-trade" data-drupal-link-system-path="node/9">Travel Trade</a>
+        
+      </li>
+                <li class="menu-item menu-item-tourism-sun-peaks menu-item--collapsed">
+
+                  <a href="/tourism-sun-peaks" title="Tourism Sun Peaks" data-drupal-link-system-path="node/12">Tourism Sun Peaks</a>
+        
+      </li>
+                <li class="menu-item menu-item-meeting-planners">
+
+                  <a href="/explore/meetings-conferences" data-drupal-link-system-path="node/106">Meeting Planners</a>
+        
+      </li>
+      </ul>
+    
+
+
+  </nav>
+
+                    </div>
+    </section>
+
+    <section class="footer">
+
+        <div class="container">
+
+            <!--<div class="promo-bar">
+
+                <h3>2019 Top 10 <br />Best Winter Trips</h3>
+                <p><strong>National Geographic</strong></p>
+                <p>
+                    <a href="https://www.nationalgeographic.com/travel/features/best-trips/where-to-go-what-to-do-winter-2019" target="_blank" class="btn-solid">Read More</a>
+                </p>
+
+            </div>-->
+
+            <div class="foot clearfix">
+
+                <div class="phone">
+                    <div class="logos">
+                        <a href="/" rel="home" class="logo">
+                            <img src="/themes/custom/sunpeaksresort/images/logo.svg" alt="Sunpeaks Resort Homepage" />
+                        </a>
+                    </div>
+                    <p>
+                        Guest Services:<br />
+                        <span><a class="phone-no text-color-white" href="tel:2505785474">250.578.5474</a></span>
+                    </p>
+                    <p>
+                        Ski Patrol Emergency:<br />
+                        <span><a class="phone-no text-color-white" href="tel:+12505785521">250.578.5521</a></span>
+                    </p>
+                    <p>
+                        <a href="/safety-risk-awareness" class="btn safety">Safety & Risk Awareness</a>
+                    </p>
+                </div>
+
+                <div class="footer-nav">
+                    <nav role="navigation" aria-labelledby="block-sunpeaksresort-footer-menu" id="block-sunpeaksresort-footer" class="block block-menu navigation menu--footer">
+            
+  <h2 class="visually-hidden" id="block-sunpeaksresort-footer-menu">Footer menu</h2>
+  
+
+        
+        <ul class="menu">
+                  <li class="menu-item menu-item-contact-us">
+
+                  <a href="/contact-us" data-drupal-link-system-path="node/13">Contact Us</a>
+        
+      </li>
+                <li class="menu-item menu-item-hours-of-operation">
+
+                  <a href="/bike-hike/summer-hours-of-operation" data-drupal-link-system-path="node/1100">Hours of Operation</a>
+        
+      </li>
+                <li class="menu-item menu-item-corporate-info menu-item--collapsed">
+
+                  <a href="/corporate-info" data-drupal-link-system-path="node/15">Corporate Info</a>
+        
+      </li>
+                <li class="menu-item menu-item-real-estate">
+
+                  <a href="/real-estate/real-estate" data-drupal-link-system-path="node/14">Real Estate</a>
+        
+      </li>
+                <li class="menu-item menu-item-employment menu-item--collapsed">
+
+                  <a href="/employment" data-drupal-link-system-path="node/16">Employment</a>
+        
+      </li>
+                <li class="menu-item menu-item-community-of-sun-peaks">
+
+                  <a href="/community-of-sun-peaks" data-drupal-link-system-path="node/18">Community of Sun Peaks</a>
+        
+      </li>
+                <li class="menu-item menu-item-corporate-partners">
+
+                  <a href="/corporate-partners" title="Corporate Partners" data-drupal-link-system-path="node/17">Corporate Partners</a>
+        
+      </li>
+                <li class="menu-item menu-item-newsletter-sign-up">
+
+                  <a href="/newsletter" data-drupal-link-system-path="node/198">Newsletter Sign-Up</a>
+        
+      </li>
+      </ul>
+    
+
+
+  </nav>
+
+                    <div class="social-icons">
+                        <a href="https://www.facebook.com/SunPeaksResort" target="_blank" class="facebook"><span>Facebook</span></a>
+                        <a href="https://www.instagram.com/sunpeaksresort/" target="_blank" class="instagram"><span>Instagram</span></a>
+                        <a href="https://www.youtube.com/user/SunPeaksResortTV" target="_blank" class="youtube"><span>YouTube</span></a>
+                        <a href="https://www.tiktok.com/@sunpeaksresort" target="_blank" class="tiktok"><span>TikTok</span></a>
+                        <a href="https://www.linkedin.com/company/sun-peaks-resort" target="_blank" class="linkedin"><span>LinkedIn</span></a>
+                        <a href="https://www.tripadvisor.ca/Tourism-g499150-Sun_Peaks_British_Columbia-Vacations.html" target="_blank" class="tripadvisor"><span>Trip Advisor</span></a>
+                    </div>
+                </div>
+
+                <ul class="reset partner-logos">
+                    <li>
+                        <img src="/themes/custom/sunpeaksresort/images/logo-ikon.svg" alt="Ikon Pass" class="ikon" />
+                    </li>
+                    <li>
+                        <img src="/themes/custom/sunpeaksresort/images/logo-mountain-collective.svg" alt="Mountain Collective" class="mountain-collective" />
+                    </li>
+                </ul>
+
+            </div>
+
+            <div class="land_acknowledgement text-align-center">
+                <p>We acknowledge that we live, work, and play on the traditional territory of the Secwépemc People.</p>
+            </div>
+
+            <div class="sole">
+
+                <div class="left address">
+                    <a href="https://goo.gl/maps/Z4HNo1XycaFXEZXb7" target="_blank">3150 Creekside Way, Sun Peaks, BC, <br /> Canada, V0E 5N0</a>
+                </div>
+
+                                    <nav role="navigation" aria-labelledby="block-privacymenu-menu" id="block-privacymenu" class="block block-menu navigation menu--privacy-menu">
+            
+  <h2 class="visually-hidden" id="block-privacymenu-menu">Privacy Menu</h2>
+  
+
+        
+              <ul class="menu">
+                    <li class="menu-item">
+        <a href="/privacy-policy" data-drupal-link-system-path="node/19">Privacy Policy</a>
+              </li>
+                <li class="menu-item">
+        <a href="/terms-of-use" data-drupal-link-system-path="node/20">Terms of Use</a>
+              </li>
+                <li class="menu-item">
+        <a href="/sitemap" data-drupal-link-system-path="sitemap">Sitemap</a>
+              </li>
+        </ul>
+  
+
+
+  </nav>
+
+                
+            </div>
+
+
+        </div>
+
+    </section>
+
+</footer>
+
+
+<div id="search-overlay" class="overlay utility-overlay" tabindex="0" role="dialog" aria-hidden="true" aria-labelledby="search-title">
+    <div class="container">
+        <div class="wrapper">
+
+            <h2 id="search-title" class="visually-hidden">Search</h2>
+
+            <div class="inner">
+                <div class="search-block-form block block-search container-inline" data-drupal-selector="search-block-form" id="block-sunpeaksresort-search" role="search">
+  
+    
+      
+
+
+<form action="/search/node" method="get" id="search-block-form" accept-charset="UTF-8">
+  <div class="js-form-item form-item js-form-type-search form-type-search js-form-item-keys form-item-keys form-no-label">
+      <label for="edit-keys" class="visually-hidden">Search</label>
+        <input title="Enter the terms you wish to search for." data-drupal-selector="edit-keys" type="search" id="edit-keys" name="keys" value="" size="15" maxlength="128" class="form-search" />
+
+        </div>
+<div data-drupal-selector="edit-actions" class="form-actions js-form-wrapper form-wrapper" id="edit-actions"><input data-drupal-selector="edit-submit" type="submit" id="edit-submit" value="Search" class="button js-form-submit form-submit" />
+</div>
+
+</form>
+
+  </div>
+
+            </div>
+
+            <a class="close" href="#">Close</a>
+
+        </div>
+
+    </div>
+</div>
+
+
+<div id="weather-overlay" class="overlay utility-overlay" tabindex="0" role="dialog" aria-hidden="true" aria-labelledby="weather-title">
+    <div class="container">
+        <div class="wrapper nano">
+            <div class="nano-content">
+
+                <h2 id="weather-title" class="visually-hidden">Current Conditions</h2>
+
+                
+<div class="inner weather current-conditions">
+
+    <a class="converter" data-unit="metric" href="#">
+        <span class="visually-hidden">Metric to Imperial converter</span>
+        <span class="metric">&deg;C/cm</span>
+        <span class="imperial">&deg;F/in</span>
+    </a>
+
+    <div class="row weather-cols">
+
+                
+        <div class="half current-temps">
+            <ul class="list-temps">
+                <li>
+                    <div class="cell">
+                        <h3>Top of the World</h3>
+                        <p>Elevation: <span class="value_switch value_m">2,080</span><span class="unit_switch unit_m">m</span></p>
+                    </div>
+                    <div class="cell">
+                        <div class="weather-value">
+                            <span class="value_switch value_deg top-temp">
+                                                                    4
+                                                            </span>
+                        </div>
+                        <div class="weather-unit">&deg;<span class="unit_switch unit_deg">C</span></div>
+                    </div>
+                </li>
+                <li>
+                    <div class="cell">
+                        <h3>Mid-mountain</h3>
+                        <p>Elevation: <span class="value_switch value_m">1,855</span><span class="unit_switch unit_m">m</span></p>
+                    </div>
+                    <div class="cell">
+                        <div class="weather-value">
+                            <span class="value_switch value_deg mid-mountain-temp">
+                                                                    5
+                                                            </span>
+                        </div>
+                        <div class="weather-unit">&deg;<span class="unit_switch unit_deg">C</span></div>
+                    </div>
+                </li>
+                <li>
+                    <div class="cell">
+                        <h3>Valley</h3>
+                        <p>Elevation: <span class="value_switch value_m">1,255</span><span class="unit_switch unit_m">m</span></p>
+                    </div>
+                    <div class="cell">
+                        <div class="weather-value">
+                            <span class="value_switch value_deg valley-temp">
+                                                                    9
+                                                            </span>
+                        </div>
+                        <div class="weather-unit">&deg;<span class="unit_switch unit_deg">C</span></div>
+                    </div>
+                </li>
+            </ul>
+        </div>
+
+        
+    </div>
+
+
+
+    <div class="row summer">
+
+        
+            
+                <div class="buttons">
+                    <div class="half">
+                        <a href="/bike-hike/weather-webcams/weather">Weather</a>
+                    </div>
+                    <div class="half">
+                        <a href="/bike-hike/weather-webcams/webcams">Webcams</a>
+                    </div>
+                </div>
+
+            
+        
+    </div>
+
+
+</div>
+
+<a class="close" href="#">Close</a>
+
+
+            </div>
+        </div>
+    </div>
+</div>
+
+
+<div id="gallery-overlay" class="overlay utility-overlay" tabindex="0">
+    <div class="container">
+        <div class="wrapper">
+
+            <div class="inner">
+                <div class="placeholder">
+                </div>
+            </div>
+
+            <a class="overlay-arrow next" href="#" >Next</a>
+            <a class="overlay-arrow prev" href="#" >Previous</a>
+
+            <a class="close" href="#">Close</a>
+
+        </div>
+
+    </div>
+</div>
+
+
+<div class="usd-rate">0.72315</div>
+
+  </div>
+
+  
+  
+
+  <script type="application/json" data-drupal-selector="drupal-settings-json">{"path":{"baseUrl":"\/","pathPrefix":"","currentPath":"node\/118","currentPathIsAdmin":false,"isFront":false,"currentLanguage":"en"},"pluralDelimiter":"\u0003","suppressDeprecationErrors":true,"lazy":{"lazysizes":{"lazyClass":"lazyload","loadedClass":"lazyloaded","loadingClass":"lazyloading","preloadClass":"lazypreload","errorClass":"lazyerror","autosizesClass":"lazyautosizes","srcAttr":"data-src","srcsetAttr":"data-srcset","sizesAttr":"data-sizes","minSize":40,"customMedia":[],"init":true,"expFactor":1.5,"hFac":0.8,"loadMode":2,"loadHidden":true,"ricTimeout":0,"throttleDelay":125,"plugins":{"object-fit":"object-fit\/ls.object-fit","parent-fit":"parent-fit\/ls.parent-fit"}},"placeholderSrc":"data:image\/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==","preferNative":false,"minified":true,"libraryPath":"\/libraries\/lazysizes"},"eu_cookie_compliance":{"cookie_policy_version":"1.0.0","popup_enabled":true,"popup_agreed_enabled":false,"popup_hide_agreed":false,"popup_clicking_confirmation":false,"popup_scrolling_confirmation":false,"popup_html_info":"\u003Cdiv aria-labelledby=\u0022popup-text\u0022  class=\u0022eu-cookie-compliance-banner eu-cookie-compliance-banner-info eu-cookie-compliance-banner--default\u0022\u003E\n  \u003Cdiv class=\u0022popup-content info eu-cookie-compliance-content\u0022\u003E\n        \u003Cdiv id=\u0022popup-text\u0022 class=\u0022eu-cookie-compliance-message\u0022 role=\u0022document\u0022\u003E\n      \u003Cp\u003EWe use cookies to enhance and personalize our ads and to analyze our traffic. This information is shared with our analytics, advertising, and social media partners. By continuing to use our site you agree to our \u003Ca href=\u0022\/privacy-policy\u0022\u003EPrivacy Policy\u003C\/a\u003E and the use of cookies.\u003C\/p\u003E\n          \u003C\/div\u003E\n\n    \n    \u003Cdiv id=\u0022popup-buttons\u0022 class=\u0022eu-cookie-compliance-buttons\u0022\u003E\n            \u003Cbutton type=\u0022button\u0022 class=\u0022agree-button eu-cookie-compliance-default-button button button--small button--primary\u0022\u003EAccept\u003C\/button\u003E\n          \u003C\/div\u003E\n  \u003C\/div\u003E\n\u003C\/div\u003E","use_mobile_message":false,"mobile_popup_html_info":"\u003Cdiv aria-labelledby=\u0022popup-text\u0022  class=\u0022eu-cookie-compliance-banner eu-cookie-compliance-banner-info eu-cookie-compliance-banner--default\u0022\u003E\n  \u003Cdiv class=\u0022popup-content info eu-cookie-compliance-content\u0022\u003E\n        \u003Cdiv id=\u0022popup-text\u0022 class=\u0022eu-cookie-compliance-message\u0022 role=\u0022document\u0022\u003E\n      \n          \u003C\/div\u003E\n\n    \n    \u003Cdiv id=\u0022popup-buttons\u0022 class=\u0022eu-cookie-compliance-buttons\u0022\u003E\n            \u003Cbutton type=\u0022button\u0022 class=\u0022agree-button eu-cookie-compliance-default-button button button--small button--primary\u0022\u003EAccept\u003C\/button\u003E\n          \u003C\/div\u003E\n  \u003C\/div\u003E\n\u003C\/div\u003E","mobile_breakpoint":768,"popup_html_agreed":false,"popup_use_bare_css":false,"popup_height":"auto","popup_width":"100%","popup_delay":1000,"popup_link":"\/privacy-policy","popup_link_new_window":true,"popup_position":false,"fixed_top_position":true,"popup_language":"en","store_consent":false,"better_support_for_screen_readers":false,"cookie_name":"","reload_page":false,"domain":"","domain_all_sites":false,"popup_eu_only":false,"popup_eu_only_js":false,"cookie_lifetime":100,"cookie_session":0,"set_cookie_session_zero_on_disagree":0,"disagree_do_not_show_popup":false,"method":"default","automatic_cookies_removal":true,"allowed_cookies":"","withdraw_markup":"\u003Cbutton type=\u0022button\u0022 class=\u0022eu-cookie-withdraw-tab\u0022\u003EPrivacy settings\u003C\/button\u003E\n\u003Cdiv aria-labelledby=\u0022popup-text\u0022 class=\u0022eu-cookie-withdraw-banner\u0022\u003E\n  \u003Cdiv class=\u0022popup-content info eu-cookie-compliance-content\u0022\u003E\n    \u003Cdiv id=\u0022popup-text\u0022 class=\u0022eu-cookie-compliance-message\u0022 role=\u0022document\u0022\u003E\n      \u003Ch2\u003EWe use cookies on this site to enhance your user experience\u003C\/h2\u003E\u003Cp\u003EYou have given your consent for us to set cookies.\u003C\/p\u003E\n    \u003C\/div\u003E\n    \u003Cdiv id=\u0022popup-buttons\u0022 class=\u0022eu-cookie-compliance-buttons\u0022\u003E\n      \u003Cbutton type=\u0022button\u0022 class=\u0022eu-cookie-withdraw-button  button button--small button--primary\u0022\u003EWithdraw consent\u003C\/button\u003E\n    \u003C\/div\u003E\n  \u003C\/div\u003E\n\u003C\/div\u003E","withdraw_enabled":false,"reload_options":0,"reload_routes_list":"","withdraw_button_on_info_popup":false,"cookie_categories":[],"cookie_categories_details":[],"enable_save_preferences_button":true,"cookie_value_disagreed":"0","cookie_value_agreed_show_thank_you":"1","cookie_value_agreed":"2","containing_element":"body","settings_tab_enabled":false,"olivero_primary_button_classes":" button button--small button--primary","olivero_secondary_button_classes":" button button--small","close_button_action":"close_banner","open_by_default":true,"modules_allow_popup":true,"hide_the_banner":false,"geoip_match":true,"unverified_scripts":[]},"ajaxTrustedUrl":{"\/search\/node":true},"user":{"uid":0,"permissionsHash":"88a04347ec6f1103bde23bb8c67b4433a7205e2760fb7cd03f85dd546b57411e"}}</script>
+<script src="/sites/default/files/js/js_0DQ9OWWjPUeXN9HnRpjNzA6fhAHWiYd2gjEwpGKGM3k.js?scope=footer&amp;delta=0&amp;language=en&amp;theme=sunpeaksresort&amp;include=eJxtyEEKgDAMBdELBXKkEstHQmNTkhbR06t7N_NgRFm07OabGGGV6t4UL8cwlV7Bf5NM7ou_UK4-IC0D6TG540zDnIgHRFwj1Q"></script>
+<script src="https://cdn.jsdelivr.net/combine/npm/formstone@1.4.18-1/src/js/core.min.js,npm/formstone@1.4.18-1/src/js/cookie.min.js,npm/nanoscroller@0.8.7"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.matchHeight/0.7.0/jquery.matchHeight-min.js"></script>
+<script src="/sites/default/files/js/js_lwb3R5GxCz2iR7sHfR5hoxDjah7hs4smGmWoLECFF-M.js?scope=footer&amp;delta=3&amp;language=en&amp;theme=sunpeaksresort&amp;include=eJxtyEEKgDAMBdELBXKkEstHQmNTkhbR06t7N_NgRFm07OabGGGV6t4UL8cwlV7Bf5NM7ou_UK4-IC0D6TG540zDnIgHRFwj1Q"></script>
+<script src="https://cdn.jsdelivr.net/combine/npm/formstone@1.4.18-1/src/js/checkbox.min.js,npm/formstone@1.4.18-1/src/js/dropdown.min.js"></script>
+<script src="/sites/default/files/js/js_AZfh5Elc67pTaoQ-cu81H-h3Bs-lp6TNQB1M_0Hg0v8.js?scope=footer&amp;delta=5&amp;language=en&amp;theme=sunpeaksresort&amp;include=eJxtyEEKgDAMBdELBXKkEstHQmNTkhbR06t7N_NgRFm07OabGGGV6t4UL8cwlV7Bf5NM7ou_UK4-IC0D6TG540zDnIgHRFwj1Q"></script>
+<script src="https://www.google.com/recaptcha/api.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-validate/1.13.1/jquery.validate.min.js"></script>
+<script src="https://files.ascent360.com/350/SunPeaks_NewsletterSignup.js"></script>
+
+</body>
+</html>


### PR DESCRIPTION
The Daily Tests have been failing since April 8 because Sun Peaks added an air quality section that reuses the ul.list-temps CSS class. The scraper was matching items from all sections (8 entries) instead of just the 4 temperature stations. This scopes the selector to div.current-temps.