### PR TITLE
Fix Daily Tests: add Golf Course webcam to expected list

### DIFF
--- a/sunpeaks_webcams/tests.py
+++ b/sunpeaks_webcams/tests.py
@@ -82,6 +82,11 @@ class CheckForNewWebcamsTests(TestCase):
                 'location': 'Village Square',
                 'elevation': "Village Base, 1,255m (4,116')"
             },
+            'Golf Course': {
+                'static_image_url': 'https://www.sunpeaksresort.com/sites/default/files/spr_website_data/webcams/Golf Course.jpg',
+                'location': 'Overlooking hole 17 on the left and hole 10 on the right',
+                'elevation': "Village Base, 1,255m (4,116')"
+            },
         }
         
         


### PR DESCRIPTION
## Problem

The **Daily Tests** workflow has been failing every day since 2026-04-17 (runs #209, #210, #211, #212).

The failing test is sunpeaks_webcams.tests.CheckForNewWebcamsTests.test_check_for_new_webcams_data:

```n AssertionError: 'Golf Course' not found in {...} : Unexpected camera_name: Golf Course
```n
## Root cause

Sun Peaks added a new `Golf Course` webcam to https://www.sunpeaksresort.com/bike-hike/weather-webcams/webcams. The test compares each scraped camera against a hardcoded `expected` dict; an unknown camera_name is treated as a hard failure.

## Fix

Add the new `Golf Course` entry to `expected` with the values currently served by the site:

- static_image_url: `https://www.sunpeaksresort.com/sites/default/files/spr_website_data/webcams/Golf Course.jpg`
- location: `Overlooking hole 17 on the left and hole 10 on the right`
- elevation: `Village Base, 1,255m (4,116')`

## Notes / follow-ups (not in this PR)

- The test will continue to be brittle to upstream content changes (any new cam will break it). Consider relaxing `assertIn(camera_name, expected)` to `if camera_name in expected:` so unknown cameras are skipped instead of failing.