### PR TITLE
vacation_mode: turn off Napoleon fireplaces

### DIFF
--- a/vacation_mode/steps.py
+++ b/vacation_mode/steps.py
@@ -266,6 +266,45 @@ VACATION_STEPS = [
         ],
     },
     {
+        "alias": "Turn Off Fireplaces",
+        "icon": "fas fa-fire",
+        "actions": [
+            {
+                "action": "climate/set_hvac_mode",
+                "data": {
+                    "entity_id": "climate.master_bedroom_2",
+                    "hvac_mode": "off",
+                },
+                "description": "Master Bedroom fireplace heater → off",
+                "delay_after": 1,
+            },
+            {
+                "action": "switch/turn_off",
+                "data": {
+                    "entity_id": "switch.master_bedroom_power",
+                },
+                "description": "Master Bedroom fireplace flames → off",
+                "delay_after": 1,
+            },
+            {
+                "action": "climate/set_hvac_mode",
+                "data": {
+                    "entity_id": "climate.living_room_fireplace",
+                    "hvac_mode": "off",
+                },
+                "description": "Living Room fireplace heater → off",
+                "delay_after": 1,
+            },
+            {
+                "action": "switch/turn_off",
+                "data": {
+                    "entity_id": "switch.living_room_fireplace_power",
+                },
+                "description": "Living Room fireplace flames → off",
+            },
+        ],
+    },
+    {
         "alias": "Enable Home Away Mode",
         "icon": "fas fa-plane-departure",
         "actions": [

--- a/vacation_mode/steps.py
+++ b/vacation_mode/steps.py
@@ -281,7 +281,7 @@ VACATION_STEPS = [
             {
                 "action": "switch/turn_off",
                 "data": {
-                    "entity_id": "switch.master_bedroom_power",
+                    "entity_id": "switch.master_bedroom",
                 },
                 "description": "Master Bedroom fireplace flames → off",
                 "delay_after": 1,
@@ -298,7 +298,7 @@ VACATION_STEPS = [
             {
                 "action": "switch/turn_off",
                 "data": {
-                    "entity_id": "switch.living_room_fireplace_power",
+                    "entity_id": "switch.living_room_fireplace",
                 },
                 "description": "Living Room fireplace flames → off",
             },


### PR DESCRIPTION
Adds a **Turn Off Fireplaces** step to VACATION_STEPS that shuts down both Napoleon fireplaces (Master Bedroom + Living Room Fireplace) — heater and flames — when vacation mode runs.

### What it does
For each fireplace it issues:
1. `climate/set_hvac_mode` → `off` (kills the heater)
2. `switch/turn_off` on the power switch (kills the flames)

Heater and flames are independent on these units (you can have flames without heat), so we hit both.

### What it does NOT do
No corresponding `HOME_STEPS` entry — fireplaces stay off until manually re-enabled (consistent with: you don't always want flames on when you arrive home).

### ⚠ Verify entity IDs before merging
Best guesses based on hass-napoleon naming conventions:
- `climate.master_bedroom_2` (assumes collision with existing thermostat → `_2` suffix)
- `climate.living_room_fireplace`
- `switch.master_bedroom_power`
- `switch.living_room_fireplace_power`

Check Developer Tools → States in HA and adjust if any differ.