### PR TITLE
Fix nightly test: add Crystal Bowl (Summer) webcam to expected set

### DIFF
--- a/sunpeaks_webcams/tests.py
+++ b/sunpeaks_webcams/tests.py
@@ -87,6 +87,11 @@ class CheckForNewWebcamsTests(TestCase):
                 'location': 'Overlooking hole 17 on the left and hole 10 on the right',
                 'elevation': "Village Base, 1,255m (4,116')"
             },
+            'Crystal Bowl (Summer)': {
+                'static_image_url': 'https://www.sunpeaksresort.com/sites/default/files/spr_website_data/webcams/Wild flowers 1.jpg',
+                'location': 'Top of Burfield Chairlift',
+                'elevation': "2,080m (6,824')"
+            },
         }
         
         


### PR DESCRIPTION
## Problem
Last night's **Daily Tests** run failed on `test_check_for_new_webcams_data` (sunpeaks_webcams):

`
AssertionError: 'Crystal Bowl (Summer)' not found in {...} : Unexpected camera_name: Crystal Bowl (Summer)
`

Not a regression. The test scrapes the live Sun Peaks webcams page and asserts every scraped camera is in an `expected` whitelist. Sun Peaks added a seasonal **Crystal Bowl (Summer)** cam that wasn't whitelisted.

## Fix
Added the new cam to the `expected` dict. Values were scraped live from the resort page so the test's location/elevation/static-URL assertions match:

| field | value |
|---|---|
| location | Top of Burfield Chairlift |
| elevation | 2,080m (6,824') |
| static_image_url | .../webcams/Wild flowers 1.jpg |

## Testing
Could not run the suite locally (no venv/Django/Postgres on this machine), but the added values are copied byte-for-byte from a live scrape of the same endpoint the test hits. The `unit-tests` CI job runs the real test against live data.
