### PR TITLE
Add Napoleon fireplace controls to Device Control

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,6 +35,13 @@ HOMEASSISTANT_URL=http://your-ha-ip:8123/
 HOMEASSISTANT_ACCESS_TOKEN=your_ha_long_lived_access_token
 
 ##############################
+#### Napoleon Fireplace #####
+##############################
+NAPOLEON_EMAIL=your_napoleon_account_email
+NAPOLEON_PASSWORD=your_napoleon_account_password
+NAPOLEON_EUROPE=false
+
+##############################
 #### go2rtc Camera Settings###
 ##############################
 # URL where go2rtc is accessible from the browser (used in camera page iframes)

--- a/BlackDiamondHub/settings.py
+++ b/BlackDiamondHub/settings.py
@@ -249,6 +249,15 @@ HOMEASSISTANT_ACCESS_TOKEN = os.environ.get('HOMEASSISTANT_ACCESS_TOKEN')
 HOMEASSISTANT_URL_2 = os.environ.get('HOMEASSISTANT_URL_2', 'http://homeassistant.local:8123')
 HOMEASSISTANT_ACCESS_TOKEN_2 = os.environ.get('HOMEASSISTANT_ACCESS_TOKEN_2')
 
+#####################################
+### Napoleon Fireplace (Ayla) Settings ###
+#####################################
+# Cloud credentials for the Napoleon fireplace (pynapoleon / Ayla IoT).
+# Leave unset to hide the fireplace controls' live data.
+NAPOLEON_EMAIL = os.environ.get('NAPOLEON_EMAIL', '')
+NAPOLEON_PASSWORD = os.environ.get('NAPOLEON_PASSWORD', '')
+NAPOLEON_EUROPE = os.environ.get('NAPOLEON_EUROPE', 'false').lower() in ('1', 'true', 'yes')
+
 ###########################
 ### go2rtc Camera Settings ###
 ###########################

--- a/device_control/device_config.py
+++ b/device_control/device_config.py
@@ -389,6 +389,21 @@ DECK_DEVICES = {
 }
 
 # ──────────────────────────────────────────────
+# Tab: Fireplace
+# ──────────────────────────────────────────────
+# The fireplace tab is NOT Home Assistant-backed. It is driven directly by the
+# Napoleon (Ayla) cloud via device_control.napoleon_client, and uses a bespoke
+# on-image control UI rather than the generic device grid. It therefore carries
+# no HA entities ("devices" is empty so get_all_entity_ids() is unaffected).
+#
+# Fireplaces are discovered dynamically from the Napoleon account. Optionally
+# override a fireplace's display name / room by DSN here; unknown DSNs fall back
+# to the name reported by the cloud.
+FIREPLACE_OVERRIDES = {
+    # "AC000W0000000000": {"name": "Living Room Fireplace", "room": "Living Room"},
+}
+
+# ──────────────────────────────────────────────
 # All tabs in display order
 # ──────────────────────────────────────────────
 TABS = [
@@ -399,6 +414,7 @@ TABS = [
     {"key": "deck", "label": "Deck", "icon": "fa-grip-lines", "devices": DECK_DEVICES},
     {"key": "tvs", "label": "TVs", "icon": "fa-tv", "devices": TV_DEVICES},
     {"key": "sonos", "label": "Sonos", "icon": "fa-music", "devices": SONOS_DEVICES},
+    {"key": "fireplace", "label": "Fireplace", "icon": "fa-fire", "devices": {}},
 ]
 
 

--- a/device_control/napoleon_client.py
+++ b/device_control/napoleon_client.py
@@ -1,0 +1,253 @@
+"""
+Async bridge between sync Django and the async ``pynapoleon`` cloud client.
+
+``pynapoleon`` talks to the Napoleon (Ayla) cloud over aiohttp and is entirely
+``async``. Django's request handling here is synchronous (WSGI), so we cannot
+simply ``asyncio.run()`` a fresh coroutine per request: the logged-in
+``NapoleonClient`` owns an aiohttp ``ClientSession`` that is bound to the event
+loop it was created on, and re-using it from a different loop raises
+``RuntimeError: ... attached to a different loop``.
+
+The robust pattern is a single **dedicated background event loop** running in
+its own daemon thread for the lifetime of the process. The cached client and
+its session live on that loop forever; sync callers submit coroutines to it via
+``asyncio.run_coroutine_threadsafe`` and block on the result.
+
+Public sync API:
+    * :func:`get_states`  -> list[dict]   (one per discovered fireplace)
+    * :func:`apply_action(dsn, action, value)` -> dict (the refreshed state)
+    * :func:`is_configured` -> bool
+
+All Ayla/network errors are surfaced as :class:`FireplaceError` so the views can
+turn them into clean JSON responses.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import threading
+from typing import Any, Callable, Coroutine
+
+from django.conf import settings
+
+logger = logging.getLogger(__name__)
+
+# How long a sync caller will block on a coroutine submitted to the loop.
+_CALL_TIMEOUT = 25  # seconds
+
+
+class FireplaceError(Exception):
+    """Any failure talking to the Napoleon cloud (auth, network, value)."""
+
+
+# ---------------------------------------------------------------------------
+# Dedicated background event-loop thread
+# ---------------------------------------------------------------------------
+class _LoopThread:
+    """Owns a single asyncio loop running in a daemon thread."""
+
+    def __init__(self) -> None:
+        self._loop = asyncio.new_event_loop()
+        self._thread = threading.Thread(
+            target=self._run, name="napoleon-loop", daemon=True
+        )
+        self._thread.start()
+
+    def _run(self) -> None:
+        asyncio.set_event_loop(self._loop)
+        self._loop.run_forever()
+
+    def run(self, coro: Coroutine[Any, Any, Any], timeout: int = _CALL_TIMEOUT) -> Any:
+        """Submit ``coro`` to the loop and block until it returns."""
+        future = asyncio.run_coroutine_threadsafe(coro, self._loop)
+        try:
+            return future.result(timeout=timeout)
+        except asyncio.TimeoutError as exc:  # pragma: no cover - network timing
+            future.cancel()
+            raise FireplaceError("Napoleon cloud request timed out") from exc
+
+
+# Lazily created so importing this module (e.g. during `manage.py check`) never
+# spins up a thread.
+_loop_thread: _LoopThread | None = None
+_loop_lock = threading.Lock()
+
+
+def _loop() -> _LoopThread:
+    global _loop_thread
+    if _loop_thread is None:
+        with _loop_lock:
+            if _loop_thread is None:
+                _loop_thread = _LoopThread()
+    return _loop_thread
+
+
+# ---------------------------------------------------------------------------
+# Cached client + fireplace handles (all live on the loop thread)
+# ---------------------------------------------------------------------------
+# These are only ever touched from coroutines running on the loop thread, so no
+# additional locking is required around them.
+_client: Any = None  # NapoleonClient
+_fireplaces: dict[str, Any] = {}  # dsn -> Fireplace
+
+
+def is_configured() -> bool:
+    """True when Napoleon cloud credentials are present in settings."""
+    return bool(
+        getattr(settings, "NAPOLEON_EMAIL", "")
+        and getattr(settings, "NAPOLEON_PASSWORD", "")
+    )
+
+
+async def _ensure_client() -> None:
+    """Log in and discover fireplaces if we don't have a live client yet."""
+    global _client, _fireplaces
+    if _client is not None and _fireplaces:
+        return
+
+    # Imported lazily so the app loads even if pynapoleon is missing.
+    from pynapoleon import NapoleonClient
+    from pynapoleon.errors import NapoleonError
+
+    email = getattr(settings, "NAPOLEON_EMAIL", "")
+    password = getattr(settings, "NAPOLEON_PASSWORD", "")
+    europe = bool(getattr(settings, "NAPOLEON_EUROPE", False))
+    if not (email and password):
+        raise FireplaceError("Napoleon credentials are not configured")
+
+    client = NapoleonClient(email, password, europe=europe)
+    try:
+        await client.login()
+        fireplaces = await client.fireplaces()
+    except NapoleonError as exc:
+        await _safe_close(client)
+        raise FireplaceError(f"Napoleon login/discovery failed: {exc}") from exc
+
+    _client = client
+    _fireplaces = {fp.dsn: fp for fp in fireplaces}
+    logger.info("Napoleon: discovered %d fireplace(s)", len(_fireplaces))
+
+
+async def _safe_close(client: Any) -> None:
+    try:
+        await client.close()
+    except Exception:  # pragma: no cover - best-effort cleanup
+        pass
+
+
+async def _reset() -> None:
+    """Drop the cached client (forces a fresh login on the next call)."""
+    global _client, _fireplaces
+    client, _client = _client, None
+    _fireplaces = {}
+    if client is not None:
+        await _safe_close(client)
+
+
+def _state_to_dict(fp: Any) -> dict[str, Any]:
+    """Serialize a Fireplace's cached state into a JSON-friendly dict."""
+    s = fp.state
+
+    def rgb(v: Any) -> list[int] | None:
+        return list(v) if v is not None else None
+
+    return {
+        "dsn": fp.dsn,
+        "name": fp.name,
+        "online": fp.is_online,  # None = unknown
+        "power": s.power,
+        "flame_speed": s.flame_speed,
+        "orange_flame": s.orange_flame,
+        "yellow_flame": s.yellow_flame,
+        "heater": s.heater,
+        "setpoint_c": s.setpoint_c,
+        "eco_mode": s.eco_mode,
+        "boost_mode": s.boost_mode,
+        "ember_bed_rgb": rgb(s.ember_bed_rgb),
+        "ember_bed_brightness": s.ember_bed_brightness,
+        "ember_bed_cycling": s.ember_bed_cycling,
+        "top_light_rgb": rgb(s.top_light_rgb),
+        "top_light_cycling": s.top_light_cycling,
+        "current_favourite": s.current_favourite,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Coroutines (run on the loop thread)
+# ---------------------------------------------------------------------------
+async def _get_states() -> list[dict[str, Any]]:
+    await _ensure_client()
+    fps = list(_fireplaces.values())
+    # Refresh all fireplaces concurrently.
+    await asyncio.gather(*(fp.refresh() for fp in fps))
+    return [_state_to_dict(fp) for fp in fps]
+
+
+# action name -> coroutine factory taking (fireplace, value)
+_ACTIONS: dict[str, Callable[[Any, Any], Coroutine[Any, Any, None]]] = {
+    "power": lambda fp, v: fp.set_power(bool(v)),
+    "flame_speed": lambda fp, v: fp.set_flame_speed(int(v)),
+    "orange_flame": lambda fp, v: fp.set_orange_flame(int(v)),
+    "yellow_flame": lambda fp, v: fp.set_yellow_flame(int(v)),
+    "heater": lambda fp, v: fp.set_heater(int(v)),
+    "setpoint_c": lambda fp, v: fp.set_setpoint_c(int(v)),
+    "eco_mode": lambda fp, v: fp.set_eco_mode(bool(v)),
+    "boost_mode": lambda fp, v: fp.set_boost_mode(bool(v)),
+    "ember_bed_rgb": lambda fp, v: fp.set_ember_bed_rgb(tuple(int(c) for c in v)),
+    "ember_bed_brightness": lambda fp, v: fp.set_ember_bed_brightness(int(v)),
+    "ember_bed_cycling": lambda fp, v: fp.set_ember_bed_cycling(bool(v)),
+    "top_light_rgb": lambda fp, v: fp.set_top_light_rgb(tuple(int(c) for c in v)),
+    "top_light_cycling": lambda fp, v: fp.set_top_light_cycling(bool(v)),
+    "favourite": lambda fp, v: fp.apply_favourite(str(v)),
+}
+
+
+async def _apply_action(dsn: str, action: str, value: Any) -> dict[str, Any]:
+    from pynapoleon.errors import NapoleonError
+
+    await _ensure_client()
+    fp = _fireplaces.get(dsn)
+    if fp is None:
+        raise FireplaceError(f"Unknown fireplace: {dsn}")
+
+    handler = _ACTIONS.get(action)
+    if handler is None:
+        raise FireplaceError(f"Unknown action: {action}")
+
+    try:
+        await handler(fp, value)
+        # Reflect the change back to the caller.
+        await fp.refresh()
+    except NapoleonError as exc:
+        raise FireplaceError(f"{action} failed: {exc}") from exc
+    return _state_to_dict(fp)
+
+
+# ---------------------------------------------------------------------------
+# Public sync API (called from Django views) — with one auth/connection retry
+# ---------------------------------------------------------------------------
+def _run_with_retry(make_coro: Callable[[], Coroutine[Any, Any, Any]]) -> Any:
+    """Run a coroutine on the loop, retrying once after a fresh login.
+
+    A cached client whose token/session has gone stale (process idle for a
+    while, cloud-side session reaped, etc.) surfaces as a FireplaceError. We
+    drop the cache, re-login, and retry exactly once before giving up.
+    """
+    loop = _loop()
+    try:
+        return loop.run(make_coro())
+    except FireplaceError:
+        logger.warning("Napoleon call failed; resetting client and retrying once")
+        loop.run(_reset())
+        return loop.run(make_coro())
+
+
+def get_states() -> list[dict[str, Any]]:
+    """Return the current state of every discovered fireplace."""
+    return _run_with_retry(_get_states)
+
+
+def apply_action(dsn: str, action: str, value: Any) -> dict[str, Any]:
+    """Apply a single control action and return the refreshed fireplace state."""
+    return _run_with_retry(lambda: _apply_action(dsn, action, value))

--- a/device_control/static/device_control/fireplace.css
+++ b/device_control/static/device_control/fireplace.css
@@ -1,0 +1,173 @@
+/* Napoleon fireplace controls — ported from fireplace_mockup_v3.html.
+   All selectors are scoped under #panel-fireplace so they never collide
+   with the main Device Control stylesheet. Keyframes stay global (names
+   are fireplace-specific). */
+
+#panel-fireplace * { box-sizing: border-box; }
+
+#panel-fireplace .fp-wrap { display: flex; flex-direction: column; min-height: 0; }
+
+/* Fireplace selector pills (only shown when >1 fireplace) */
+#panel-fireplace .fp-select { display: flex; gap: 10px; justify-content: center; padding: 8px 20px; flex-shrink: 0; flex-wrap: wrap; }
+#panel-fireplace .fp-pill { display: flex; align-items: center; gap: 10px; background: #2a2a2a; border: 1px solid #444; border-radius: 10px;
+           padding: 8px 14px; cursor: pointer; min-width: 220px; transition: border-color .15s, background .15s; }
+#panel-fireplace .fp-pill:hover { background: #333; }
+#panel-fireplace .fp-pill.active { border-color: #FFD700; background: #2f2a1e; }
+#panel-fireplace .fp-pill .pill-ic { width: 34px; height: 34px; border-radius: 8px; background: #1f1f1f; display: flex; align-items: center;
+           justify-content: center; font-size: 1.1rem; color: #555; border: 1px solid #3a3a3a; }
+#panel-fireplace .fp-pill.on .pill-ic { color: #FF7A18; background: #2a1a0e; box-shadow: 0 0 10px rgba(255,122,24,.4); }
+#panel-fireplace .fp-pill .pill-txt b { font-size: .9rem; color: #eee; display: block; }
+#panel-fireplace .fp-pill .pill-txt span { font-size: .72rem; color: #999; }
+#panel-fireplace .dot { font-size: .5rem; vertical-align: middle; margin-right: 4px; }
+#panel-fireplace .dot.online { color: #4caf50; }
+#panel-fireplace .dot.offline { color: #f44336; }
+
+#panel-fireplace .fp-detail { flex: 1; display: grid; grid-template-columns: 1fr; gap: 16px; padding: 4px 20px 8px; min-height: 0; }
+
+/* ---- PREVIEW with on-image hotspots ---- */
+#panel-fireplace .preview-wrap { background: #1a1a1a; border: 1px solid #444; border-radius: 12px; position: relative; overflow: hidden;
+                display: flex; flex-direction: column; }
+#panel-fireplace .preview-top { display: flex; align-items: center; gap: 12px; padding: 12px 16px; z-index: 6; }
+#panel-fireplace .preview-top .pt-name { font-size: 1.1rem; font-weight: 700; color: #fff; flex: 1; }
+#panel-fireplace .preview-top .pt-status { font-size: .8rem; color: #FFD700; font-weight: 600; }
+#panel-fireplace .preview-top .hint { font-size: .72rem; color: #888; }
+
+#panel-fireplace .firebox { position: relative; flex: 1; margin: 0 18px 18px; border-radius: 10px; overflow: hidden;
+           background: radial-gradient(ellipse at 50% 120%, #2a2018 0%, #141414 55%, #0c0c0c 100%);
+           border: 2px solid #333; box-shadow: inset 0 0 60px rgba(0,0,0,.8); }
+#panel-fireplace .top-glow { position: absolute; top: 0; left: 0; right: 0; height: 80px; opacity: 0; transition: opacity .4s;
+            background: radial-gradient(ellipse at 50% 0%, var(--top-color, #fff) 0%, transparent 70%); filter: blur(4px); }
+#panel-fireplace .ember-bed { position: absolute; bottom: 0; left: 8%; right: 8%; height: 50px; border-radius: 50% 50% 6px 6px / 80% 80% 6px 6px;
+             background: radial-gradient(ellipse at 50% 100%, var(--ember-color, #ff5a1e) 0%, transparent 75%);
+             opacity: var(--ember-bri, .6); filter: blur(3px); transition: opacity .4s, background .4s; }
+#panel-fireplace .ember-bed.cycle { animation: fpEmberCycle 6s linear infinite; }
+@keyframes fpEmberCycle { 0%{filter:blur(3px) hue-rotate(0);} 100%{filter:blur(3px) hue-rotate(360deg);} }
+
+/* log bed — sits on the ember bed, flames rise in front of it */
+#panel-fireplace .logs { position: absolute; bottom: 6px; left: 3%; right: 3%; height: 64px; pointer-events: none; }
+#panel-fireplace .log { position: absolute; bottom: 0; height: 24px; border-radius: 13px;
+       background: linear-gradient(to top, #170f08 0%, #341f12 45%, #4a2e1b 80%, #5a3a22 100%);
+       box-shadow: inset 0 3px 7px rgba(255,150,50,.18), inset 0 -3px 6px rgba(0,0,0,.7), 0 -2px 8px rgba(0,0,0,.55); }
+#panel-fireplace .log::after { content: ""; position: absolute; top: 50%; width: 16px; height: 16px; margin-top: -8px; border-radius: 50%;
+              background: radial-gradient(circle, #ff8a2e 0%, #c0481a 55%, #2a1206 100%); box-shadow: 0 0 10px rgba(255,120,40,.6); }
+#panel-fireplace .log.l1 { left: 2%;  width: 44%; transform: rotate(-2.5deg); }
+#panel-fireplace .log.l1::after { right: -6px; }
+#panel-fireplace .log.l2 { right: 2%; width: 44%; transform: rotate(2.5deg); }
+#panel-fireplace .log.l2::after { left: -6px; }
+#panel-fireplace .log.l3 { left: 27%; width: 46%; bottom: 17px; height: 22px; transform: rotate(-1deg); }
+#panel-fireplace .log.l3::after { right: -6px; }
+#panel-fireplace .preview-wrap.on .log::after { animation: fpLogGlow 3.4s ease-in-out infinite; }
+@keyframes fpLogGlow { 0%,100%{ opacity:.85; } 50%{ opacity:1; filter:brightness(1.25); } }
+
+#panel-fireplace .flames { position: absolute; bottom: 24px; left: 2%; right: 2%; display: flex; align-items: flex-end; justify-content: center;
+          height: 82%; opacity: 0; transition: opacity .5s; pointer-events: none; }
+/* soft glowing mass of fire behind the tongues, for depth */
+#panel-fireplace .flames::before { content: ""; position: absolute; left: 0; right: 0; bottom: -6px; height: 58%; z-index: 0;
+          background: radial-gradient(ellipse at 50% 100%, rgba(255,160,50,.6) 0%, rgba(255,95,20,.28) 45%, transparent 75%);
+          filter: blur(16px); animation: fpGlowPulse 3.2s ease-in-out infinite; }
+@keyframes fpGlowPulse { 0%,100%{ opacity:.75; transform: scaleY(1); } 50%{ opacity:1; transform: scaleY(1.08); } }
+
+#panel-fireplace .flame { position: relative; z-index: 1; flex: 1 1 0; min-width: 0; height: calc(var(--flame-h, .5) * 100%); margin: 0 -7px;
+         border-radius: 50% 50% 46% 46% / 94% 94% 22% 22%; transform-origin: bottom center;
+         background: linear-gradient(to top, #fff0bf 0%, var(--flame-c2, #ffd24a) 24%, var(--flame-c1, #ff7a18) 62%, rgba(220,70,15,.35) 86%, transparent 100%);
+         filter: blur(4px); animation: fpFlicker 1.5s ease-in-out infinite; }
+#panel-fireplace .flame.f2 { flex-grow: 1.2; height: calc(var(--flame-h,.5) * 120%); animation-duration: 1.9s; animation-delay: -.4s; opacity: .94; }
+#panel-fireplace .flame.f3 { flex-grow: .82; height: calc(var(--flame-h,.5) * 82%); animation-duration: 1.25s; animation-delay: -.8s; }
+#panel-fireplace .flame.core { flex: 0 0 30px; filter: blur(2.5px); background: linear-gradient(to top, #ffd98c 0%, #fff6da 72%, rgba(255,255,220,.4) 100%); opacity: .95; }
+#panel-fireplace .flame:nth-child(2n) { animation-delay: -.55s; border-radius: 48% 48% 46% 46% / 92% 92% 26% 26%; }
+#panel-fireplace .flame:nth-child(3n) { animation-delay: -1.0s; }
+#panel-fireplace .flame:nth-child(5n) { animation-delay: -1.35s; }
+#panel-fireplace .flame:nth-child(3n+1) { border-radius: 46% 54% 47% 47% / 96% 90% 24% 24%; }
+@keyframes fpFlicker { 0%,100%{ transform: scaleY(1) scaleX(1) rotate(0deg) translateX(0); }
+                     25%{ transform: scaleY(1.1) scaleX(.92) rotate(-2.5deg) translateX(-3px); }
+                     50%{ transform: scaleY(.95) scaleX(1.05) rotate(1deg) translateX(2px); }
+                     75%{ transform: scaleY(1.07) scaleX(.94) rotate(2.5deg) translateX(3px); } }
+
+/* rising embers */
+#panel-fireplace .embers { position: absolute; left: 6%; right: 6%; bottom: 26px; top: 6%; pointer-events: none; opacity: 0; transition: opacity .5s; }
+#panel-fireplace .ember { position: absolute; bottom: 0; border-radius: 50%;
+         background: radial-gradient(circle, #ffe39e 0%, #ff7a1e 55%, transparent 78%); opacity: 0;
+         animation: fpRise linear infinite; }
+@keyframes fpRise { 0%{ transform: translateY(0) translateX(0) scale(1); opacity: 0; }
+                  12%{ opacity: var(--op,1); } 75%{ opacity: calc(var(--op,1) * .8); }
+                  100%{ transform: translateY(var(--rh,-200px)) translateX(var(--rx,8px)) scale(.25); opacity: 0; } }
+#panel-fireplace .preview-wrap.on .flames { opacity: 1; }
+#panel-fireplace .preview-wrap.on .embers { opacity: 1; }
+#panel-fireplace .preview-wrap.on .top-glow.lit { opacity: .85; }
+#panel-fireplace .preview-wrap.off .firebox { filter: grayscale(.4) brightness(.8); }
+#panel-fireplace .off-overlay { position: absolute; inset: 0; display: flex; align-items: center; justify-content: center; color: #666;
+               font-size: .9rem; gap: 8px; z-index: 2; }
+#panel-fireplace .preview-wrap.on .off-overlay { display: none; }
+
+/* Hotspots (pucks) */
+#panel-fireplace .hotspot { position: absolute; z-index: 7; width: 46px; margin-left: -23px; }
+#panel-fireplace .hotspot.power { margin-left: 0; }
+#panel-fireplace .puck { width: 46px; height: 46px; border-radius: 50%; background: #1b1b1b; border: 1px solid rgba(255,255,255,.45);
+        color: #fff; font-size: 1.1rem; cursor: pointer; display: flex; align-items: center; justify-content: center;
+        box-shadow: 0 2px 8px rgba(0,0,0,.55), 0 0 0 3px rgba(255,215,0,.12); position: relative; transition: transform .12s, border-color .15s; }
+#panel-fireplace .puck:hover { transform: scale(1.08); border-color: #FFD700; }
+#panel-fireplace .puck[disabled] { opacity: .5; cursor: not-allowed; }
+#panel-fireplace .hotspot.open .puck { border-color: #FFD700; background: #3a2f12; transform: scale(1.08); }
+#panel-fireplace .puck .plabel { position: absolute; top: 50px; left: 50%; transform: translateX(-50%); white-space: nowrap; font-size: .64rem;
+                color: #ddd; background: rgba(0,0,0,.7); padding: 2px 7px; border-radius: 4px; opacity: 0; transition: opacity .15s; pointer-events: none; }
+#panel-fireplace .hotspot:not(.open) .puck:hover .plabel { opacity: 1; }
+#panel-fireplace .preview-wrap.off .hotspot:not(.power) { display: none; }
+
+/* Popover */
+#panel-fireplace .pop { position: absolute; left: 50%; margin-left: -120px; width: 240px; background: #232323; border: 1px solid #555;
+       border-radius: 10px; padding: 12px; box-shadow: 0 8px 28px rgba(0,0,0,.6); z-index: 9; display: none; }
+#panel-fireplace .hotspot.open .pop { display: block; }
+#panel-fireplace .hotspot.below .pop { top: 56px; }
+#panel-fireplace .hotspot.above .pop { bottom: 56px; }
+#panel-fireplace .hotspot.heat .pop { left: 50%; margin-left: -18px; width: 250px; }
+#panel-fireplace .pop h4 { margin: 0 0 8px; font-size: .76rem; text-transform: uppercase; letter-spacing: .6px; color: #FFD700; display: flex; align-items: center; gap: 7px; }
+
+#panel-fireplace .power .puck { width: 52px; height: 52px; font-size: 1.2rem; }
+#panel-fireplace .preview-wrap.on .power .puck { color: #FFD700; border-color: #FFD700; }
+
+/* shared control widgets */
+#panel-fireplace .row { display: flex; align-items: center; gap: 10px; margin: 8px 0; }
+#panel-fireplace .row .rl { font-size: .78rem; color: #cfcfcf; width: 70px; min-width: 70px; }
+#panel-fireplace .row .rv { font-size: .78rem; color: #FFD700; font-weight: 700; min-width: 34px; text-align: right; }
+#panel-fireplace .sld { flex: 1; -webkit-appearance: none; appearance: none; height: 26px; border-radius: 4px; background: #444; border: 1px solid #555; outline: none; cursor: pointer; }
+#panel-fireplace .sld::-webkit-slider-thumb { -webkit-appearance: none; width: 22px; height: 30px; border-radius: 4px; background: #FFD700; border: 2px solid #333; cursor: pointer; }
+#panel-fireplace .sld.flamesld::-webkit-slider-thumb { background: #FF7A18; }
+#panel-fireplace .swatch { width: 40px; height: 28px; border-radius: 5px; border: 2px solid #555; cursor: pointer; flex-shrink: 0; padding: 0; background: none; -webkit-appearance: none; appearance: none; }
+#panel-fireplace .swatch::-webkit-color-swatch-wrapper { padding: 0; }
+#panel-fireplace .swatch::-webkit-color-swatch { border: none; border-radius: 3px; }
+#panel-fireplace .mini-row { display: flex; align-items: center; gap: 10px; margin: 8px 0; }
+#panel-fireplace .mini-row .rl { flex: 1; font-size: .78rem; color: #cfcfcf; }
+#panel-fireplace .fp-toggle { position: relative; display: inline-block; width: 50px; height: 27px; flex-shrink: 0; }
+#panel-fireplace .fp-toggle input { opacity: 0; width: 0; height: 0; }
+#panel-fireplace .tt { position: absolute; cursor: pointer; inset: 0; background: #555; border-radius: 4px; border: 1px solid #666; transition: background .25s; }
+#panel-fireplace .tt::after { content:''; position: absolute; width: 21px; height: 21px; left: 3px; bottom: 2px; background: #ccc; border-radius: 4px; transition: transform .25s, background .25s; }
+#panel-fireplace .fp-toggle input:checked + .tt { background: #D4A843; border-color: #D4A843; }
+#panel-fireplace .fp-toggle input:checked + .tt::after { transform: translateX(23px); background: #fff; }
+
+/* ---- bottom presets bar ---- */
+#panel-fireplace .presets-bar { padding: 0 20px 14px; flex-shrink: 0; }
+#panel-fireplace .presets-bar .ctl.disabled { opacity: .4; pointer-events: none; }
+#panel-fireplace .presets-bar .ctl h3 { text-align: center; justify-content: center; }
+#panel-fireplace .presets-bar .presets { display: grid; grid-template-columns: repeat(4, 1fr); gap: 10px; }
+#panel-fireplace .presets-bar .preset { justify-content: center; padding: 12px 8px; }
+
+#panel-fireplace .ctl { background: #2a2a2a; border: 1px solid #444; border-radius: 10px; padding: 12px 14px; }
+#panel-fireplace .ctl.disabled { opacity: .4; pointer-events: none; }
+#panel-fireplace .ctl h3 { margin: 0 0 10px; font-size: .78rem; text-transform: uppercase; letter-spacing: .6px; color: #ddd; display: flex; align-items: center; gap: 8px; }
+#panel-fireplace .ctl h3 i { color: #FFD700; }
+#panel-fireplace .presets { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; }
+#panel-fireplace .preset { background: #2f2a22; border: 1px solid #4a4030; color: #e8d9b0; border-radius: 8px; padding: 10px 8px; font-size: .8rem; font-weight: 600; cursor: pointer; display: flex; align-items: center; gap: 9px; }
+#panel-fireplace .preset:hover { background: #3a3326; }
+#panel-fireplace .preset.active { background: #5a3d18; border-color: #FFD700; color: #fff; }
+#panel-fireplace .preset i { color: #FF9A3C; }
+#panel-fireplace .seg { display: flex; border-radius: 6px; overflow: hidden; border: 1px solid #555; flex: 1; }
+#panel-fireplace .seg button { flex: 1; background: #333; color: #aaa; border: none; padding: 8px 4px; font-size: .78rem; font-weight: 600; cursor: pointer; border-right: 1px solid #555; }
+#panel-fireplace .seg button:last-child { border-right: none; }
+#panel-fireplace .seg button.active { background: #B5562A; color: #fff; }
+#panel-fireplace .stepper { display: flex; align-items: center; gap: 8px; }
+#panel-fireplace .stepper button { width: 32px; height: 32px; border-radius: 7px; border: 1px solid #555; background: #333; color: #fff; font-size: 1rem; cursor: pointer; }
+#panel-fireplace .stepper .tv { font-size: 1.2rem; font-weight: 700; color: #FFD700; min-width: 58px; text-align: center; }
+
+/* states for empty / error / not-configured */
+#panel-fireplace .fp-msg { text-align: center; color: #999; padding: 40px 20px; font-size: .95rem; }
+#panel-fireplace .fp-msg i { color: #FFD700; margin-right: 8px; }

--- a/device_control/static/device_control/fireplace.js
+++ b/device_control/static/device_control/fireplace.js
@@ -1,0 +1,421 @@
+/* Napoleon fireplace controls — ported from fireplace_mockup_v3.html and
+   wired to the real backend:
+     GET  api/fireplace/states/   -> { configured, fireplaces:[ state… ] }  (or { configured, error })
+     POST api/fireplace/action/   body { dsn, action, value }  -> { ok, fireplace:{…} }
+
+   The backend state dict uses different field names than the mockup; toView()
+   adapts a backend record into the mockup-shaped object the render code expects,
+   and the *_ACTION / RAW_FIELD maps translate UI changes back to backend
+   actions + cached-field writes. RGB is [r,g,b] on the wire, hex in the UI. */
+(function () {
+    const ROOT = document.getElementById('panel-fireplace');
+    if (!ROOT) return;  // fireplace tab not present
+
+    const STATES_URL = ROOT.dataset.statesUrl;
+    const ACTION_URL = ROOT.dataset.actionUrl;
+    const CSRF = ROOT.dataset.csrf;
+
+    const PRESETS = [
+        { slot: "partytime", name: "Party Time", icon: "fa-champagne-glasses" },
+        { slot: "campfirewarmth", name: "Campfire", icon: "fa-campground" },
+        { slot: "summerday", name: "Summer Day", icon: "fa-sun" },
+        { slot: "glowingsunset", name: "Sunset", icon: "fa-mountain-sun" },
+    ];
+    const HEATER = ["Off", "Low", "High"];
+
+    // mockup-key -> backend action name (for sliders/steppers)
+    const SET_ACTION = { flame_speed: 'flame_speed', orange_flame: 'orange_flame',
+                         yellow_flame: 'yellow_flame', ember_bri: 'ember_bed_brightness' };
+    // mockup-flag -> backend action name (booleans; top_on handled specially)
+    const FLAG_ACTION = { eco: 'eco_mode', boost: 'boost_mode',
+                          top_cycle: 'top_light_cycling', ember_cycle: 'ember_bed_cycling' };
+    // mockup-color -> backend action name
+    const COLOR_ACTION = { top_rgb: 'top_light_rgb', ember_rgb: 'ember_bed_rgb' };
+    // mockup-key -> backend cached-state field name (to mutate STATES optimistically)
+    const RAW_FIELD = {
+        flame_speed: 'flame_speed', orange_flame: 'orange_flame', yellow_flame: 'yellow_flame',
+        ember_bri: 'ember_bed_brightness', eco: 'eco_mode', boost: 'boost_mode',
+        top_cycle: 'top_light_cycling', ember_cycle: 'ember_bed_cycling',
+        top_rgb: 'top_light_rgb', ember_rgb: 'ember_bed_rgb',
+    };
+
+    // raw backend records, current selection, open popover, transient-edit guard
+    let STATES = [];
+    let configured = true;
+    let loadError = null;
+    let sel = 0;
+    let openPop = null;
+    let editing = false;   // true while a slider/color picker is being dragged
+
+    const sels = {
+        select: ROOT.querySelector('#fpSelect'),
+        preview: ROOT.querySelector('#preview'),
+        presets: ROOT.querySelector('#presetsBar'),
+    };
+
+    // ── helpers ──────────────────────────────────────────────
+    function clamp(v, lo, hi) { return Math.max(lo, Math.min(hi, v)); }
+    function isArr3(a) { return Array.isArray(a) && a.length === 3; }
+    function rgbArrToHex(a) {
+        if (!isArr3(a)) return '#ff5a1e';
+        return '#' + a.map(x => clamp(+x | 0, 0, 255).toString(16).padStart(2, '0')).join('');
+    }
+    function hexToRgbArr(hex) {
+        const m = /^#?([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})$/i.exec(hex || '');
+        return m ? [parseInt(m[1], 16), parseInt(m[2], 16), parseInt(m[3], 16)] : [255, 90, 30];
+    }
+    function isNonBlack(a) { return isArr3(a) && (a[0] | a[1] | a[2]) > 0; }
+
+    // backend record -> mockup-shaped view object used by the render code
+    function toView(s) {
+        return {
+            dsn: s.dsn,
+            name: s.name || s.dsn,
+            online: s.online !== false,           // null (unknown) and true both render as online-ish
+            power: !!s.power,
+            flame_speed: s.flame_speed == null ? 1 : s.flame_speed,
+            orange_flame: s.orange_flame == null ? 0 : s.orange_flame,
+            yellow_flame: s.yellow_flame == null ? 0 : s.yellow_flame,
+            heater: s.heater == null ? 0 : s.heater,
+            setpoint_c: s.setpoint_c == null ? 20 : s.setpoint_c,
+            eco: !!s.eco_mode,
+            boost: !!s.boost_mode,
+            ember_rgb: rgbArrToHex(s.ember_bed_rgb),
+            ember_bri: s.ember_bed_brightness == null ? 0 : s.ember_bed_brightness,
+            ember_cycle: !!s.ember_bed_cycling,
+            top_rgb: rgbArrToHex(s.top_light_rgb),
+            top_cycle: !!s.top_light_cycling,
+            top_on: isNonBlack(s.top_light_rgb),
+            favourite: s.current_favourite || null,
+        };
+    }
+    function view() { return toView(STATES[sel]); }
+
+    function statusText(f) {
+        if (!f.online) return "Offline";
+        if (!f.power) return "Standby";
+        return `On · ${f.setpoint_c}°C · Flame ${f.flame_speed}`;
+    }
+
+    // ── network ──────────────────────────────────────────────
+    function sendAction(action, value) {
+        const dsn = STATES[sel] && STATES[sel].dsn;
+        if (!dsn) return Promise.resolve();
+        return fetch(ACTION_URL, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json', 'X-CSRFToken': CSRF },
+            body: JSON.stringify({ dsn, action, value }),
+        })
+            .then(r => r.json().then(d => ({ ok: r.ok, d })))
+            .then(({ ok, d }) => {
+                if (ok && d && d.fireplace) {
+                    // reconcile cached record from authoritative response (by dsn)
+                    const idx = STATES.findIndex(s => s.dsn === d.fireplace.dsn);
+                    if (idx >= 0) STATES[idx] = d.fireplace;
+                    // refresh visuals only — don't rebuild markup / close the popover
+                    if (idx === sel) applyVisual();
+                } else if (!ok) {
+                    console.error('fireplace action failed', action, d);
+                }
+            })
+            .catch(err => console.error('fireplace action error', action, err));
+    }
+
+    function fetchStates() {
+        return fetch(STATES_URL)
+            .then(r => r.json())
+            .then(data => {
+                configured = data.configured !== false;
+                loadError = data.error || null;
+                const list = Array.isArray(data.fireplaces) ? data.fireplaces : [];
+                // keep the user's current selection pinned to its dsn across refreshes
+                const curDsn = STATES[sel] && STATES[sel].dsn;
+                STATES = list;
+                if (curDsn) {
+                    const i = STATES.findIndex(s => s.dsn === curDsn);
+                    sel = i >= 0 ? i : 0;
+                } else {
+                    sel = 0;
+                }
+                renderAll();
+            })
+            .catch(err => {
+                console.error('fireplace states error', err);
+                loadError = 'Could not reach the fireplace service.';
+                renderAll();
+            });
+    }
+
+    // ── render ───────────────────────────────────────────────
+    function showMessage(html) {
+        sels.select.innerHTML = '';
+        sels.presets.innerHTML = '';
+        sels.preview.className = 'preview-wrap';
+        sels.preview.innerHTML = `<div class="fp-msg">${html}</div>`;
+    }
+
+    function renderSelect() {
+        if (STATES.length <= 1) { sels.select.innerHTML = ''; return; }
+        sels.select.innerHTML = STATES.map((raw, i) => {
+            const f = toView(raw);
+            return `
+            <div class="fp-pill ${f.power ? 'on' : ''} ${i === sel ? 'active' : ''}" data-sel="${i}">
+                <div class="pill-ic"><i class="fa-solid fa-fire"></i></div>
+                <div class="pill-txt"><b>${f.name}</b>
+                    <span><span class="dot ${f.online ? 'online' : 'offline'}">●</span>${statusText(f)}</span></div>
+            </div>`;
+        }).join('');
+        sels.select.querySelectorAll('[data-sel]').forEach(el => el.onclick = () => {
+            sel = +el.dataset.sel; openPop = null; renderAll();
+        });
+    }
+
+    function applyVisual() {
+        const f = view();
+        const p = sels.preview;
+        p.classList.toggle('on', f.power); p.classList.toggle('off', !f.power);
+        p.style.setProperty('--flame-h', (0.15 + f.flame_speed * 0.07).toFixed(2));
+        p.style.setProperty('--flame-c1', '#ff7a18');
+        p.style.setProperty('--flame-c2', f.yellow_flame >= f.orange_flame ? '#ffe066' : '#ffb030');
+        p.style.setProperty('--ember-color', f.ember_rgb);
+        p.style.setProperty('--ember-bri', (f.ember_bri / 4).toFixed(2));
+        p.style.setProperty('--top-color', f.top_rgb);
+        const eb = p.querySelector('.ember-bed'); if (eb) eb.classList.toggle('cycle', f.ember_cycle);
+        const tg = p.querySelector('.top-glow'); if (tg) tg.classList.toggle('lit', f.top_on);
+        const st = p.querySelector('.pt-status');
+        if (st) st.innerHTML = `<span class="dot ${f.online ? 'online' : 'offline'}">●</span> ${statusText(f)}`;
+    }
+
+    function emberSpans() {
+        let s = '';
+        for (let i = 0; i < 55; i++) {
+            const left = (2 + Math.random() * 96).toFixed(1);
+            const dur = (2.2 + Math.random() * 3.6).toFixed(2);
+            const delay = (-Math.random() * 6).toFixed(2);
+            const rh = -(120 + Math.random() * 170).toFixed(0);
+            const rx = (Math.random() * 60 - 30).toFixed(0);
+            const sz = (1.5 + Math.random() * 7).toFixed(1);
+            const op = (0.6 + Math.random() * 0.4).toFixed(2);
+            s += `<span class="ember" style="left:${left}%; width:${sz}px; height:${sz}px; --op:${op}; animation-duration:${dur}s; animation-delay:${delay}s; --rh:${rh}px; --rx:${rx}px;"></span>`;
+        }
+        return s;
+    }
+
+    const FLAMES = '<div class="flame f3"></div><div class="flame"></div><div class="flame f2"></div><div class="flame"></div><div class="flame f3"></div><div class="flame core"></div><div class="flame f2"></div><div class="flame"></div><div class="flame f3"></div><div class="flame"></div><div class="flame core"></div><div class="flame"></div><div class="flame f3"></div><div class="flame"></div><div class="flame f2"></div><div class="flame core"></div><div class="flame f3"></div><div class="flame"></div><div class="flame f2"></div><div class="flame"></div><div class="flame f3"></div>';
+
+    function renderPreview() {
+        const f = view();
+        const p = sels.preview;
+        p.innerHTML = `
+        <div class="preview-top">
+            <div class="pt-name">${f.name}</div>
+            <div class="pt-status"></div>
+        </div>
+        <div class="firebox">
+            <div class="top-glow"></div>
+            <div class="ember-bed"></div>
+            <div class="logs"><div class="log l1"></div><div class="log l2"></div><div class="log l3"></div></div>
+            <div class="flames">${FLAMES}</div>
+            <div class="embers">${emberSpans()}</div>
+            <div class="off-overlay"><i class="fa-regular fa-snowflake"></i> ${f.online ? 'Fireplace is off — tap power' : 'Offline'}</div>
+
+            <!-- HEAT -->
+            <div class="hotspot below heat ${openPop === 'heat' ? 'open' : ''}" data-hs="heat" style="top:10px; left:13%;">
+                <button class="puck" data-puck="heat"><i class="fa-solid fa-temperature-half"></i><span class="plabel">Heat</span></button>
+                <div class="pop"><h4><i class="fa-solid fa-temperature-half"></i> Heat</h4>
+                    <div class="row"><span class="rl">Heater</span><div class="seg">${HEATER.map((h, hi) => `<button class="${f.heater === hi ? 'active' : ''}" data-heater="${hi}">${h}</button>`).join('')}</div></div>
+                    <div class="row"><span class="rl">Target</span><div class="stepper"><button data-temp="-1"><i class="fa-solid fa-minus"></i></button><span class="tv">${f.setpoint_c}°C</span><button data-temp="1"><i class="fa-solid fa-plus"></i></button></div></div>
+                    <div class="mini-row"><span class="rl">Eco Mode</span><label class="fp-toggle"><input type="checkbox" ${f.eco ? 'checked' : ''} data-flag="eco"><span class="tt"></span></label></div>
+                    <div class="mini-row"><span class="rl">Boost Mode</span><label class="fp-toggle"><input type="checkbox" ${f.boost ? 'checked' : ''} data-flag="boost"><span class="tt"></span></label></div>
+                </div>
+            </div>
+
+            <!-- TOP LIGHT -->
+            <div class="hotspot below ${openPop === 'top' ? 'open' : ''}" data-hs="top" style="top:10px; left:50%;">
+                <button class="puck" data-puck="top"><i class="fa-solid fa-lightbulb"></i><span class="plabel">Top Light</span></button>
+                <div class="pop"><h4><i class="fa-solid fa-lightbulb"></i> Top Light</h4>
+                    <div class="row"><span class="rl">Color</span><input type="color" class="swatch" value="${f.top_rgb}" data-color="top_rgb"></div>
+                    <div class="mini-row"><span class="rl">On</span><label class="fp-toggle"><input type="checkbox" ${f.top_on ? 'checked' : ''} data-flag="top_on"><span class="tt"></span></label></div>
+                    <div class="mini-row"><span class="rl">Color Cycle</span><label class="fp-toggle"><input type="checkbox" ${f.top_cycle ? 'checked' : ''} data-flag="top_cycle"><span class="tt"></span></label></div>
+                </div>
+            </div>
+
+            <!-- FLAME -->
+            <div class="hotspot below ${openPop === 'flame' ? 'open' : ''}" data-hs="flame" style="top:42%; left:50%;">
+                <button class="puck" data-puck="flame"><i class="fa-solid fa-fire-flame-curved"></i><span class="plabel">Flame</span></button>
+                <div class="pop"><h4><i class="fa-solid fa-fire-flame-curved"></i> Flame</h4>
+                    <div class="row"><span class="rl">Height</span><input type="range" class="sld flamesld" min="1" max="5" value="${f.flame_speed}" data-set="flame_speed"><span class="rv">${f.flame_speed}/5</span></div>
+                    <div class="row"><span class="rl">Orange</span><input type="range" class="sld flamesld" min="0" max="4" value="${f.orange_flame}" data-set="orange_flame"><span class="rv">${f.orange_flame}/4</span></div>
+                    <div class="row"><span class="rl">Yellow</span><input type="range" class="sld flamesld" min="0" max="4" value="${f.yellow_flame}" data-set="yellow_flame"><span class="rv">${f.yellow_flame}/4</span></div>
+                </div>
+            </div>
+
+            <!-- EMBER BED -->
+            <div class="hotspot above ${openPop === 'ember' ? 'open' : ''}" data-hs="ember" style="bottom:14px; left:50%;">
+                <button class="puck" data-puck="ember"><i class="fa-solid fa-fire"></i><span class="plabel">Ember Bed</span></button>
+                <div class="pop"><h4><i class="fa-solid fa-fire"></i> Ember Bed</h4>
+                    <div class="row"><span class="rl">Color</span><input type="color" class="swatch" value="${f.ember_rgb}" data-color="ember_rgb"></div>
+                    <div class="row"><span class="rl">Bright</span><input type="range" class="sld" min="0" max="4" value="${f.ember_bri}" data-set="ember_bri"><span class="rv">${f.ember_bri}/4</span></div>
+                    <div class="mini-row"><span class="rl">Color Cycle</span><label class="fp-toggle"><input type="checkbox" ${f.ember_cycle ? 'checked' : ''} data-flag="ember_cycle"><span class="tt"></span></label></div>
+                </div>
+            </div>
+
+            <!-- POWER -->
+            <div class="hotspot power" data-hs="power" style="top:12px; right:12px;">
+                <button class="puck" data-puck="power" ${f.online ? '' : 'disabled'}><i class="fa-solid fa-power-off"></i><span class="plabel">${f.power ? 'Turn Off' : 'Turn On'}</span></button>
+            </div>
+        </div>`;
+        wirePreview();
+        applyVisual();
+    }
+
+    function wirePreview() {
+        const p = sels.preview;
+        const raw = () => STATES[sel];
+
+        p.querySelectorAll('[data-puck]').forEach(b => b.onclick = (e) => {
+            e.stopPropagation();
+            const k = b.dataset.puck;
+            const f = view();
+            if (k === 'power') {
+                if (!f.online) return;
+                const next = !f.power;
+                raw().power = next;
+                openPop = null;
+                renderAll();
+                sendAction('power', next);
+                return;
+            }
+            openPop = (openPop === k) ? null : k;
+            renderPreview();
+        });
+
+        // sliders / steppers (continuous): update locally, debounce the POST
+        p.querySelectorAll('[data-set]').forEach(el => {
+            el.addEventListener('pointerdown', () => { editing = true; });
+            el.addEventListener('touchstart', () => { editing = true; }, { passive: true });
+            el.oninput = () => {
+                const key = el.dataset.set;
+                const val = +el.value;
+                raw()[RAW_FIELD[key]] = val;
+                el.parentElement.querySelector('.rv').textContent =
+                    el.value + (key === 'flame_speed' ? '/5' : '/4');
+                applyVisual();
+                debounce(key, () => sendAction(SET_ACTION[key], val));
+            };
+            const stop = () => { editing = false; };
+            el.addEventListener('pointerup', stop);
+            el.addEventListener('touchend', stop);
+            el.addEventListener('change', stop);
+        });
+
+        // boolean flags
+        p.querySelectorAll('[data-flag]').forEach(el => el.onchange = () => {
+            const flag = el.dataset.flag;
+            const checked = el.checked;
+            if (flag === 'top_on') {
+                // no dedicated setter: derive on/off from rgb (white when on, black when off)
+                const rgb = checked ? [255, 255, 255] : [0, 0, 0];
+                raw().top_light_rgb = rgb;
+                applyVisual();
+                sendAction('top_light_rgb', rgb);
+                return;
+            }
+            raw()[RAW_FIELD[flag]] = checked;
+            applyVisual();
+            sendAction(FLAG_ACTION[flag], checked);
+        });
+
+        // color pickers
+        p.querySelectorAll('[data-color]').forEach(el => {
+            el.addEventListener('pointerdown', () => { editing = true; });
+            el.oninput = () => {
+                const key = el.dataset.color;
+                const rgb = hexToRgbArr(el.value);
+                raw()[RAW_FIELD[key]] = rgb;
+                applyVisual();
+                debounce(key, () => sendAction(COLOR_ACTION[key], rgb));
+            };
+            el.addEventListener('change', () => { editing = false; });
+        });
+
+        // heater segmented
+        p.querySelectorAll('[data-heater]').forEach(el => el.onclick = (e) => {
+            e.stopPropagation();
+            const hi = +el.dataset.heater;
+            raw().heater = hi;
+            renderPreview();
+            sendAction('heater', hi);
+        });
+
+        // temperature stepper
+        p.querySelectorAll('[data-temp]').forEach(el => el.onclick = (e) => {
+            e.stopPropagation();
+            const f = view();
+            const next = clamp(f.setpoint_c + (+el.dataset.temp), 18, 30);
+            raw().setpoint_c = next;
+            renderPreview();
+            sendAction('setpoint_c', next);
+        });
+
+        // keep popover open when interacting inside it
+        p.querySelectorAll('.pop').forEach(pop => pop.onclick = e => e.stopPropagation());
+    }
+
+    function renderPresets() {
+        const f = view();
+        const dis = f.power ? '' : 'disabled';
+        sels.presets.innerHTML = `
+        <div class="ctl ${dis}"><h3><i class="fa-solid fa-wand-magic-sparkles"></i> Presets / Moods</h3>
+            <div class="presets">${PRESETS.map(pr => `<button class="preset ${f.favourite === pr.slot ? 'active' : ''}" data-preset="${pr.slot}"><i class="fa-solid ${pr.icon}"></i>${pr.name}</button>`).join('')}</div>
+        </div>`;
+        sels.presets.querySelectorAll('[data-preset]').forEach(el => el.onclick = () => {
+            const slot = el.dataset.preset;
+            STATES[sel].current_favourite = slot;
+            renderAll();
+            sendAction('favourite', slot);
+        });
+    }
+
+    function renderAll() {
+        if (!configured) {
+            showMessage('<i class="fa-solid fa-circle-info"></i> Fireplace cloud is not configured. Set NAPOLEON_EMAIL and NAPOLEON_PASSWORD on the server.');
+            return;
+        }
+        if (loadError) {
+            showMessage(`<i class="fa-solid fa-triangle-exclamation"></i> ${loadError}`);
+            return;
+        }
+        if (!STATES.length) {
+            showMessage('<i class="fa-solid fa-fire"></i> No fireplaces found on this account.');
+            return;
+        }
+        renderSelect();
+        renderPreview();
+        renderPresets();
+    }
+
+    // ── debounce for continuous controls ─────────────────────
+    const debTimers = {};
+    function debounce(key, fn) {
+        if (debTimers[key]) clearTimeout(debTimers[key]);
+        debTimers[key] = setTimeout(fn, 350);
+    }
+
+    // ── body click closes popover (only on the active fireplace tab) ─
+    document.body.addEventListener('click', () => {
+        if (!ROOT.classList.contains('active')) return;
+        if (openPop) { openPop = null; renderPreview(); }
+    });
+
+    // ── poll — skip while a popover is open or a control is being dragged ─
+    function poll() {
+        if (openPop || editing) return;
+        fetchStates();
+    }
+
+    // initial load + 9s refresh
+    showMessage('<i class="fa-solid fa-spinner fa-spin"></i> Loading fireplace…');
+    fetchStates();
+    setInterval(poll, 9000);
+})();

--- a/device_control/templates/device_control/device_control.html
+++ b/device_control/templates/device_control/device_control.html
@@ -1,8 +1,10 @@
 {% extends 'base.html' %}
+{% load static %}
 
 {% block title %}Device Control{% endblock %}
 
 {% block content %}
+<link rel="stylesheet" href="{% static 'device_control/fireplace.css' %}">
 <style>
     html, body {
         height: 100%;
@@ -653,7 +655,19 @@
 <!-- Content -->
 <div class="dc-container">
     {% for tab in tabs %}
-    <div id="panel-{{ tab.key }}" class="dc-panel{% if forloop.first %} active{% endif %}">
+    <div id="panel-{{ tab.key }}" class="dc-panel{% if forloop.first %} active{% endif %}"{% if tab.key == "fireplace" %}
+         data-states-url="{% url 'device_control_fireplace_states' %}"
+         data-action-url="{% url 'device_control_fireplace_action' %}"
+         data-csrf="{{ csrf_token }}"{% endif %}>
+        {% if tab.key == "fireplace" %}
+        <div class="fp-wrap">
+            <div class="fp-select" id="fpSelect"></div>
+            <div class="fp-detail">
+                <div class="preview-wrap" id="preview"></div>
+            </div>
+            <div class="presets-bar" id="presetsBar"></div>
+        </div>
+        {% else %}
         <div class="dc-loading" id="loading-{{ tab.key }}">
             <i class="fas fa-spinner"></i>
             <p>Loading devices...</p>
@@ -762,6 +776,7 @@
             </div>{# /dc-group-panel #}
             {% endfor %}
         </div>
+        {% endif %}
     </div>
     {% endfor %}
 
@@ -1362,4 +1377,5 @@
         });
     }
 </script>
+<script src="{% static 'device_control/fireplace.js' %}"></script>
 {% endblock %}

--- a/device_control/tests.py
+++ b/device_control/tests.py
@@ -226,6 +226,183 @@ class ViewTests(TestCase):
         self.assertFalse(data["ok"])
 
 
+class FireplaceViewTests(TestCase):
+    """Tests for the Napoleon fireplace endpoints (mocked napoleon_client)."""
+
+    def _state(self, **over):
+        base = {
+            "dsn": "AC000W000000001",
+            "name": "Living Room Fireplace",
+            "online": None,
+            "power": True,
+            "flame_speed": 3,
+            "orange_flame": 2,
+            "yellow_flame": 1,
+            "heater": 1,
+            "setpoint_c": 21,
+            "eco_mode": False,
+            "boost_mode": False,
+            "ember_bed_rgb": [255, 120, 0],
+            "ember_bed_brightness": 3,
+            "ember_bed_cycling": False,
+            "top_light_rgb": [0, 0, 0],
+            "top_light_cycling": False,
+            "current_favourite": None,
+        }
+        base.update(over)
+        return base
+
+    # ----- states endpoint -----
+
+    @patch("device_control.views.napoleon_client.is_configured", return_value=False)
+    def test_states_not_configured(self, _cfg):
+        resp = self.client.get(reverse("device_control_fireplace_states"))
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertFalse(data["configured"])
+        self.assertEqual(data["fireplaces"], [])
+
+    @patch("device_control.views.napoleon_client.get_states")
+    @patch("device_control.views.napoleon_client.is_configured", return_value=True)
+    def test_states_success(self, _cfg, mock_states):
+        mock_states.return_value = [self._state()]
+        resp = self.client.get(reverse("device_control_fireplace_states"))
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertTrue(data["configured"])
+        self.assertEqual(len(data["fireplaces"]), 1)
+        self.assertEqual(data["fireplaces"][0]["dsn"], "AC000W000000001")
+
+    @patch("device_control.views.napoleon_client.get_states")
+    @patch("device_control.views.napoleon_client.is_configured", return_value=True)
+    def test_states_cloud_error_returns_502(self, _cfg, mock_states):
+        mock_states.side_effect = views.napoleon_client.FireplaceError("cloud down")
+        resp = self.client.get(reverse("device_control_fireplace_states"))
+        self.assertEqual(resp.status_code, 502)
+        data = resp.json()
+        self.assertTrue(data["configured"])
+        self.assertIn("error", data)
+
+    # ----- action endpoint -----
+
+    def test_action_requires_post(self):
+        resp = self.client.get(reverse("device_control_fireplace_action"))
+        self.assertEqual(resp.status_code, 405)
+
+    def test_action_rejects_bad_json(self):
+        resp = self.client.post(
+            reverse("device_control_fireplace_action"),
+            data="not json",
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, 400)
+
+    def test_action_rejects_missing_dsn(self):
+        resp = self.client.post(
+            reverse("device_control_fireplace_action"),
+            data='{"action": "power", "value": true}',
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, 400)
+
+    def test_action_rejects_unknown_action(self):
+        resp = self.client.post(
+            reverse("device_control_fireplace_action"),
+            data='{"dsn": "AC1", "action": "explode", "value": true}',
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, 400)
+
+    def test_action_rejects_bad_value_type(self):
+        # flame_speed must be an int 1..5
+        resp = self.client.post(
+            reverse("device_control_fireplace_action"),
+            data='{"dsn": "AC1", "action": "flame_speed", "value": 9}',
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, 400)
+
+    def test_action_rejects_bad_rgb(self):
+        resp = self.client.post(
+            reverse("device_control_fireplace_action"),
+            data='{"dsn": "AC1", "action": "ember_bed_rgb", "value": [300, 0, 0]}',
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, 400)
+
+    @patch("device_control.views.napoleon_client.is_configured", return_value=False)
+    def test_action_not_configured_returns_503(self, _cfg):
+        resp = self.client.post(
+            reverse("device_control_fireplace_action"),
+            data='{"dsn": "AC1", "action": "power", "value": true}',
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, 503)
+
+    @patch("device_control.views.napoleon_client.apply_action")
+    @patch("device_control.views.napoleon_client.is_configured", return_value=True)
+    def test_action_success(self, _cfg, mock_apply):
+        mock_apply.return_value = self._state(power=False)
+        resp = self.client.post(
+            reverse("device_control_fireplace_action"),
+            data='{"dsn": "AC000W000000001", "action": "power", "value": false}',
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertTrue(data["ok"])
+        self.assertFalse(data["fireplace"]["power"])
+        mock_apply.assert_called_once_with("AC000W000000001", "power", False)
+
+    @patch("device_control.views.napoleon_client.apply_action")
+    @patch("device_control.views.napoleon_client.is_configured", return_value=True)
+    def test_action_favourite_valid(self, _cfg, mock_apply):
+        mock_apply.return_value = self._state(current_favourite="partytime")
+        resp = self.client.post(
+            reverse("device_control_fireplace_action"),
+            data='{"dsn": "AC000W000000001", "action": "favourite", "value": "partytime"}',
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, 200)
+        mock_apply.assert_called_once_with("AC000W000000001", "favourite", "partytime")
+
+    def test_action_favourite_invalid_slot(self):
+        resp = self.client.post(
+            reverse("device_control_fireplace_action"),
+            data='{"dsn": "AC1", "action": "favourite", "value": "disco"}',
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, 400)
+
+    @patch("device_control.views.napoleon_client.apply_action")
+    @patch("device_control.views.napoleon_client.is_configured", return_value=True)
+    def test_action_cloud_error_returns_502(self, _cfg, mock_apply):
+        mock_apply.side_effect = views.napoleon_client.FireplaceError("timeout")
+        resp = self.client.post(
+            reverse("device_control_fireplace_action"),
+            data='{"dsn": "AC1", "action": "power", "value": true}',
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, 502)
+        self.assertFalse(resp.json()["ok"])
+
+
+class FireplaceTabTests(TestCase):
+    """The fireplace tab must render its dedicated panel structure."""
+
+    def test_fireplace_panel_rendered(self):
+        resp = self.client.get(reverse("device_control"))
+        content = resp.content.decode()
+        self.assertIn('id="panel-fireplace"', content)
+        self.assertIn('id="fpSelect"', content)
+        self.assertIn('id="preview"', content)
+        self.assertIn('id="presetsBar"', content)
+        self.assertIn('data-states-url', content)
+        self.assertIn('data-action-url', content)
+        self.assertIn('fireplace.js', content)
+        self.assertIn('fireplace.css', content)
+
+
 @tag('selenium')
 class DeviceControlShadesSliderTest(StaticLiveServerTestCase):
     """Ensure shade cards render a position slider that fits within the card."""

--- a/device_control/urls.py
+++ b/device_control/urls.py
@@ -5,4 +5,6 @@ urlpatterns = [
     path('', views.device_control_view, name='device_control'),
     path('api/states/', views.device_control_states, name='device_control_states'),
     path('api/action/', views.device_control_action, name='device_control_action'),
+    path('api/fireplace/states/', views.device_control_fireplace_states, name='device_control_fireplace_states'),
+    path('api/fireplace/action/', views.device_control_fireplace_action, name='device_control_fireplace_action'),
 ]

--- a/device_control/views.py
+++ b/device_control/views.py
@@ -14,8 +14,9 @@ from django.http import JsonResponse
 from django.shortcuts import render
 from django.views.decorators.http import require_POST
 
-from .device_config import TABS, get_all_entity_ids
+from .device_config import TABS, get_all_entity_ids, FIREPLACE_OVERRIDES
 from .ha_client import call_service, get_entity_states
+from . import napoleon_client
 
 logger = logging.getLogger(__name__)
 
@@ -134,3 +135,110 @@ def device_control_action(request):
         return JsonResponse({"ok": True, "entity_id": entity_id, "action": action})
     else:
         return JsonResponse({"ok": False, "error": error}, status=502)
+
+
+# ──────────────────────────────────────────────
+# Fireplace (Napoleon cloud) endpoints
+# ──────────────────────────────────────────────
+# These bypass Home Assistant entirely and talk to the Napoleon (Ayla) cloud
+# through device_control.napoleon_client. Validation of action names is done
+# against the bridge's own action map.
+
+# Action -> validator for the supplied value. Anything not listed is rejected.
+_FIREPLACE_ACTION_VALIDATORS = {
+    "power": lambda v: isinstance(v, bool),
+    "flame_speed": lambda v: isinstance(v, int) and 1 <= v <= 5,
+    "orange_flame": lambda v: isinstance(v, int) and 0 <= v <= 4,
+    "yellow_flame": lambda v: isinstance(v, int) and 0 <= v <= 4,
+    "heater": lambda v: v in (0, 1, 2),
+    "setpoint_c": lambda v: isinstance(v, int) and 18 <= v <= 30,
+    "eco_mode": lambda v: isinstance(v, bool),
+    "boost_mode": lambda v: isinstance(v, bool),
+    "ember_bed_rgb": lambda v: _is_rgb(v),
+    "ember_bed_brightness": lambda v: isinstance(v, int) and 0 <= v <= 4,
+    "ember_bed_cycling": lambda v: isinstance(v, bool),
+    "top_light_rgb": lambda v: _is_rgb(v),
+    "top_light_cycling": lambda v: isinstance(v, bool),
+    "favourite": lambda v: v in (
+        "partytime",
+        "campfirewarmth",
+        "summerday",
+        "glowingsunset",
+    ),
+}
+
+
+def _is_rgb(v):
+    return (
+        isinstance(v, (list, tuple))
+        and len(v) == 3
+        and all(isinstance(c, int) and 0 <= c <= 255 for c in v)
+    )
+
+
+def _apply_overrides(state):
+    """Apply optional name/room overrides from device_config to a state dict."""
+    override = FIREPLACE_OVERRIDES.get(state.get("dsn"))
+    if override:
+        if override.get("name"):
+            state["name"] = override["name"]
+        if override.get("room"):
+            state["room"] = override["room"]
+    return state
+
+
+def device_control_fireplace_states(request):
+    """AJAX endpoint: current state of every discovered fireplace.
+
+    Returns JSON: { "configured": bool, "fireplaces": [ {...}, ... ] }
+    """
+    if not napoleon_client.is_configured():
+        return JsonResponse({"configured": False, "fireplaces": []})
+
+    try:
+        states = napoleon_client.get_states()
+    except napoleon_client.FireplaceError as exc:
+        logger.warning("Fireplace states fetch failed: %s", exc)
+        return JsonResponse({"configured": True, "error": str(exc)}, status=502)
+
+    states = [_apply_overrides(s) for s in states]
+    return JsonResponse({"configured": True, "fireplaces": states})
+
+
+@require_POST
+def device_control_fireplace_action(request):
+    """AJAX endpoint: apply a control action to a fireplace.
+
+    Expects JSON body: { dsn, action, value }
+    Returns the refreshed fireplace state on success.
+    """
+    try:
+        body = json.loads(request.body)
+    except (json.JSONDecodeError, ValueError):
+        return JsonResponse({"error": "Invalid JSON"}, status=400)
+
+    dsn = body.get("dsn", "")
+    action = body.get("action", "")
+    value = body.get("value")
+
+    if not dsn:
+        return JsonResponse({"error": "Missing dsn"}, status=400)
+
+    validator = _FIREPLACE_ACTION_VALIDATORS.get(action)
+    if validator is None:
+        return JsonResponse({"error": f"Unknown action: {action}"}, status=400)
+    if not validator(value):
+        return JsonResponse(
+            {"error": f"Invalid value for {action}: {value!r}"}, status=400
+        )
+
+    if not napoleon_client.is_configured():
+        return JsonResponse({"error": "Napoleon not configured"}, status=503)
+
+    try:
+        state = napoleon_client.apply_action(dsn, action, value)
+    except napoleon_client.FireplaceError as exc:
+        logger.warning("Fireplace action %s failed: %s", action, exc)
+        return JsonResponse({"ok": False, "error": str(exc)}, status=502)
+
+    return JsonResponse({"ok": True, "fireplace": _apply_overrides(state)})

--- a/requirements.txt
+++ b/requirements.txt
@@ -79,3 +79,4 @@ zope.interface==7.0.3
 python-dateutil
 pytz
 websockets
+pynapoleon==0.0.2


### PR DESCRIPTION
## Napoleon Fireplace Controls

Adds a **Fireplace** tab to Device Control with an on-image direct-manipulation UI (tap glowing pucks to open control popovers), ported faithfully from the approved mockup v3 and wired to the Napoleon (Ayla) cloud via `pynapoleon`.

### Backend
- `napoleon_client.py` — async `pynapoleon` bridged to sync Django through a dedicated event-loop thread; `get_states()`, `apply_action(dsn, action, value)`, `is_configured()`, auth-retry.
- `views.py` — `GET api/fireplace/states/` → `{configured, fireplaces[]}`; `POST api/fireplace/action/` `{dsn, action, value}` → `{ok, fireplace}` with strict per-action value validation.
- `device_config.py` — fireplace tab + optional name/room overrides.
- `settings.py` / `requirements.txt` / `.env.example` — `NAPOLEON_EMAIL` / `NAPOLEON_PASSWORD` / `NAPOLEON_EUROPE`.

### Frontend
- `static/device_control/fireplace.css` + `fireplace.js` — scoped under `#panel-fireplace`; IIFE reads endpoint URLs + CSRF from the panel dataset, adapts backend↔mockup field names, optimistic updates, debounced sliders, 9 s poll paused while a popover is open or a control is being dragged.
- `device_control.html` — dedicated fireplace panel, static load tags, kept out of the generic Home Assistant poll path.

### Tests
- Mocked view tests for both endpoints (not-configured, success, 502/503/400 error paths, POST-only, value validation) and fireplace panel rendering.

### Validation
- `py_compile` (all Python) ✅
- `node --check fireplace.js` ✅
- Django template parse (tag balance) ✅
- Full `manage.py test` runs in CI (no local Django/postgres env on Windows).

### Before live use
Add `NAPOLEON_EMAIL` / `NAPOLEON_PASSWORD` (and `NAPOLEON_EUROPE` if applicable) to `.env`.
