### PR TITLE
Pass Napoleon fireplace env vars through to the Django container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,6 +51,11 @@ services:
       # Sonos discovery interface (needed with host networking)
       SONOS_INTERFACE: ${SONOS_INTERFACE:-}
 
+      # Napoleon Fireplace (Ayla cloud)
+      NAPOLEON_EMAIL: ${NAPOLEON_EMAIL}
+      NAPOLEON_PASSWORD: ${NAPOLEON_PASSWORD}
+      NAPOLEON_EUROPE: ${NAPOLEON_EUROPE}
+
     network_mode: host
     
     restart: unless-stopped


### PR DESCRIPTION
The djangoapp service uses an explicit \nvironment:\ mapping (not \nv_file:\), so a var being in \.env\ isn't enough — it must also be listed here to reach the container. \NAPOLEON_*\ were added to \.env.example\ in the fireplace PR but never to this passthrough, so the integration only worked because homehub's working-tree compose was hand-edited; a future \git pull\ would silently drop it and the fireplaces would go unconfigured.

Adds the 3 \NAPOLEON_*\ passthroughs. Values stay in \.env\ — these lines only reference \\\, no secrets.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>