### PR TITLE
Add Gemstone Lights device control tab

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,6 +42,12 @@ NAPOLEON_PASSWORD=your_napoleon_account_password
 NAPOLEON_EUROPE=false
 
 ##############################
+#### Gemstone Lights     #####
+##############################
+GEMSTONE_EMAIL=your_gemstone_account_email
+GEMSTONE_PASSWORD=your_gemstone_account_password
+
+##############################
 #### go2rtc Camera Settings###
 ##############################
 # URL where go2rtc is accessible from the browser (used in camera page iframes)

--- a/BlackDiamondHub/settings.py
+++ b/BlackDiamondHub/settings.py
@@ -258,6 +258,14 @@ NAPOLEON_EMAIL = os.environ.get('NAPOLEON_EMAIL', '')
 NAPOLEON_PASSWORD = os.environ.get('NAPOLEON_PASSWORD', '')
 NAPOLEON_EUROPE = os.environ.get('NAPOLEON_EUROPE', 'false').lower() in ('1', 'true', 'yes')
 
+#####################################
+### Gemstone Lights Settings ###
+#####################################
+# Cloud credentials for Gemstone Lights (pygemstone / AWS Amplify).
+# Leave unset to hide the Gemstone controls' live data.
+GEMSTONE_EMAIL = os.environ.get('GEMSTONE_EMAIL', '')
+GEMSTONE_PASSWORD = os.environ.get('GEMSTONE_PASSWORD', '')
+
 ###########################
 ### go2rtc Camera Settings ###
 ###########################

--- a/device_control/device_config.py
+++ b/device_control/device_config.py
@@ -404,6 +404,22 @@ FIREPLACE_OVERRIDES = {
 }
 
 # ──────────────────────────────────────────────
+# Tab: Gemstone Lights
+# ──────────────────────────────────────────────
+# The gemstone tab is NOT Home Assistant-backed. It is driven directly by the
+# Gemstone Lights cloud via device_control.gemstone_client, and uses a bespoke
+# device-card UI (power toggle + saved-pattern picker) rather than the generic
+# device grid. It therefore carries no HA entities ("devices" is empty so
+# get_all_entity_ids() is unaffected).
+#
+# Devices are discovered dynamically from the Gemstone account. Optionally
+# override a device's display name / room by device id here; unknown ids fall
+# back to the name reported by the cloud.
+GEMSTONE_OVERRIDES = {
+    # "device-uuid": {"name": "Roofline", "room": "Exterior"},
+}
+
+# ──────────────────────────────────────────────
 # All tabs in display order
 # ──────────────────────────────────────────────
 TABS = [
@@ -415,6 +431,7 @@ TABS = [
     {"key": "tvs", "label": "TVs", "icon": "fa-tv", "devices": TV_DEVICES},
     {"key": "sonos", "label": "Sonos", "icon": "fa-music", "devices": SONOS_DEVICES},
     {"key": "fireplace", "label": "Fireplace", "icon": "fa-fire", "devices": {}},
+    {"key": "gemstone", "label": "Gemstone", "icon": "fa-gem", "devices": {}},
 ]
 
 

--- a/device_control/gemstone_client.py
+++ b/device_control/gemstone_client.py
@@ -1,0 +1,307 @@
+"""
+Async bridge between sync Django and the async ``pygemstone`` cloud client.
+
+``pygemstone`` talks to the Gemstone Lights (AWS Amplify / Cognito) cloud over
+aiohttp and is entirely ``async``. Django's request handling here is synchronous
+(WSGI), so we cannot simply ``asyncio.run()`` a fresh coroutine per request: the
+logged-in ``GemstoneClient`` owns an aiohttp ``ClientSession`` bound to the event
+loop it was created on, and re-using it from a different loop raises
+``RuntimeError: ... attached to a different loop``.
+
+The robust pattern (identical to ``napoleon_client``) is a single **dedicated
+background event loop** running in its own daemon thread for the lifetime of the
+process. The cached client + session + device handles live on that loop forever;
+sync callers submit coroutines to it via ``asyncio.run_coroutine_threadsafe`` and
+block on the result.
+
+Public sync API:
+    * :func:`get_states`  -> dict  {"devices": [...], "patterns": [...]}
+    * :func:`apply_action(device_id, action, value)` -> dict (refreshed state)
+    * :func:`is_configured` -> bool
+
+All cloud/network errors are surfaced as :class:`GemstoneError` so the views can
+turn them into clean JSON responses.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import threading
+from typing import Any, Callable, Coroutine
+
+from django.conf import settings
+
+logger = logging.getLogger(__name__)
+
+# How long a sync caller will block on a coroutine submitted to the loop.
+_CALL_TIMEOUT = 25  # seconds
+
+# How many pages of saved patterns to pull when discovering the catalogue.
+_MAX_PATTERN_PAGES = 5
+
+
+class GemstoneError(Exception):
+    """Any failure talking to the Gemstone cloud (auth, network, value)."""
+
+
+# ---------------------------------------------------------------------------
+# Dedicated background event-loop thread
+# ---------------------------------------------------------------------------
+class _LoopThread:
+    """Owns a single asyncio loop running in a daemon thread."""
+
+    def __init__(self) -> None:
+        self._loop = asyncio.new_event_loop()
+        self._thread = threading.Thread(
+            target=self._run, name="gemstone-loop", daemon=True
+        )
+        self._thread.start()
+
+    def _run(self) -> None:
+        asyncio.set_event_loop(self._loop)
+        self._loop.run_forever()
+
+    def run(self, coro: Coroutine[Any, Any, Any], timeout: int = _CALL_TIMEOUT) -> Any:
+        """Submit ``coro`` to the loop and block until it returns."""
+        future = asyncio.run_coroutine_threadsafe(coro, self._loop)
+        try:
+            return future.result(timeout=timeout)
+        except asyncio.TimeoutError as exc:  # pragma: no cover - network timing
+            future.cancel()
+            raise GemstoneError("Gemstone cloud request timed out") from exc
+
+
+# Lazily created so importing this module (e.g. during `manage.py check`) never
+# spins up a thread.
+_loop_thread: _LoopThread | None = None
+_loop_lock = threading.Lock()
+
+
+def _loop() -> _LoopThread:
+    global _loop_thread
+    if _loop_thread is None:
+        with _loop_lock:
+            if _loop_thread is None:
+                _loop_thread = _LoopThread()
+    return _loop_thread
+
+
+# ---------------------------------------------------------------------------
+# Cached client + handles (all live on the loop thread)
+# ---------------------------------------------------------------------------
+# These are only ever touched from coroutines running on the loop thread, so no
+# additional locking is required around them.
+_client: Any = None  # GemstoneClient
+_devices: dict[str, Any] = {}  # device_id -> Device
+_patterns_by_id: dict[str, Any] = {}  # pattern_id -> Pattern (for replay)
+_patterns_ui: list[dict[str, Any]] = []  # JSON-friendly catalogue for the UI
+
+
+def is_configured() -> bool:
+    """True when Gemstone cloud credentials are present in settings."""
+    return bool(
+        getattr(settings, "GEMSTONE_EMAIL", "")
+        and getattr(settings, "GEMSTONE_PASSWORD", "")
+    )
+
+
+def _color_to_hex(c: Any) -> str:
+    """Best-effort conversion of a packed integer colour to ``#rrggbb``."""
+    try:
+        n = int(c)
+    except (TypeError, ValueError):
+        return "#000000"
+    return "#%06x" % (n & 0xFFFFFF)
+
+
+async def _ensure_client() -> None:
+    """Log in and discover devices + saved patterns if we have no live client."""
+    global _client, _devices, _patterns_by_id, _patterns_ui
+    if _client is not None and _devices:
+        return
+
+    # Imported lazily so the app loads even if pygemstone is missing.
+    from pygemstone import GemstoneClient
+    from pygemstone.errors import GemstoneError as LibGemstoneError
+
+    email = getattr(settings, "GEMSTONE_EMAIL", "")
+    password = getattr(settings, "GEMSTONE_PASSWORD", "")
+    if not (email and password):
+        raise GemstoneError("Gemstone credentials are not configured")
+
+    client = GemstoneClient(email, password)
+    try:
+        # __aenter__ creates the aiohttp session on THIS loop; we drive the
+        # context manager manually because the client is cached for the
+        # process lifetime rather than scoped to a single ``async with``.
+        await client.__aenter__()
+        await client.login()
+        devices = await client.devices()
+        patterns = await _discover_patterns(client)
+    except LibGemstoneError as exc:
+        await _safe_close(client)
+        raise GemstoneError(f"Gemstone login/discovery failed: {exc}") from exc
+    except Exception as exc:  # noqa: BLE001 - surface any startup failure cleanly
+        await _safe_close(client)
+        raise GemstoneError(f"Gemstone login/discovery failed: {exc}") from exc
+
+    _client = client
+    _devices = {d.id: d for d in devices}
+
+    by_id: dict[str, Any] = {}
+    ui: list[dict[str, Any]] = []
+    for fp in patterns:
+        pat = fp.pattern
+        pid = getattr(pat, "id", "") or ""
+        if not pid or pid in by_id:
+            continue
+        by_id[pid] = pat
+        ui.append(
+            {
+                "id": pid,
+                "name": pat.name or "Pattern",
+                "colors": [_color_to_hex(c) for c in (pat.colors or [])],
+                "is_favorite": bool(getattr(fp, "is_favorite", False)),
+            }
+        )
+    # Favourites first, then alphabetical — stable, friendly ordering.
+    ui.sort(key=lambda p: (not p["is_favorite"], p["name"].lower()))
+    _patterns_by_id = by_id
+    _patterns_ui = ui
+    logger.info(
+        "Gemstone: discovered %d device(s), %d saved pattern(s)",
+        len(_devices),
+        len(_patterns_ui),
+    )
+
+
+async def _discover_patterns(client: Any) -> list[Any]:
+    """Pull the user's saved patterns across a bounded number of pages."""
+    out: list[Any] = []
+    for page in range(1, _MAX_PATTERN_PAGES + 1):
+        chunk = await client.folder_patterns(page=page)
+        if not chunk:
+            break
+        out.extend(chunk)
+    return out
+
+
+async def _safe_close(client: Any) -> None:
+    try:
+        await client.__aexit__(None, None, None)
+    except Exception:  # pragma: no cover - best-effort cleanup
+        pass
+
+
+async def _reset() -> None:
+    """Drop the cached client (forces a fresh login on the next call)."""
+    global _client, _devices, _patterns_by_id, _patterns_ui
+    client, _client = _client, None
+    _devices = {}
+    _patterns_by_id = {}
+    _patterns_ui = []
+    if client is not None:
+        await _safe_close(client)
+
+
+def _state_to_dict(dev: Any) -> dict[str, Any]:
+    """Serialize a Device's cached state into a JSON-friendly dict."""
+    s = dev.state  # DeviceState | None
+    pattern = getattr(s, "pattern", None) if s is not None else None
+    return {
+        "id": dev.id,
+        "name": dev.name,
+        "online": not bool(getattr(dev.record, "disconnect_reason", None)),
+        "power": bool(getattr(s, "on_state", False)) if s is not None else False,
+        "pattern_id": getattr(pattern, "id", None) if pattern else None,
+        "pattern_name": getattr(pattern, "name", None) if pattern else None,
+        "pattern_colors": (
+            [_color_to_hex(c) for c in (pattern.colors or [])] if pattern else []
+        ),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Coroutines (run on the loop thread)
+# ---------------------------------------------------------------------------
+async def _get_states() -> dict[str, Any]:
+    await _ensure_client()
+    devs = list(_devices.values())
+    # Refresh all devices concurrently.
+    await asyncio.gather(*(dev.refresh() for dev in devs))
+    return {
+        "devices": [_state_to_dict(dev) for dev in devs],
+        "patterns": list(_patterns_ui),
+    }
+
+
+async def _set_power(dev: Any, value: Any) -> None:
+    if bool(value):
+        await dev.turn_on()
+    else:
+        await dev.turn_off()
+
+
+async def _play_pattern(dev: Any, value: Any) -> None:
+    pattern = _patterns_by_id.get(str(value))
+    if pattern is None:
+        raise GemstoneError(f"Unknown pattern: {value}")
+    await dev.play_pattern(pattern)
+
+
+# action name -> coroutine factory taking (device, value)
+_ACTIONS: dict[str, Callable[[Any, Any], Coroutine[Any, Any, None]]] = {
+    "power": _set_power,
+    "pattern": _play_pattern,
+}
+
+
+async def _apply_action(device_id: str, action: str, value: Any) -> dict[str, Any]:
+    from pygemstone.errors import GemstoneError as LibGemstoneError
+
+    await _ensure_client()
+    dev = _devices.get(device_id)
+    if dev is None:
+        raise GemstoneError(f"Unknown device: {device_id}")
+
+    handler = _ACTIONS.get(action)
+    if handler is None:
+        raise GemstoneError(f"Unknown action: {action}")
+
+    try:
+        await handler(dev, value)
+        # Reflect the change back to the caller.
+        await dev.refresh()
+    except LibGemstoneError as exc:
+        raise GemstoneError(f"{action} failed: {exc}") from exc
+    return _state_to_dict(dev)
+
+
+# ---------------------------------------------------------------------------
+# Public sync API (called from Django views) — with one auth/connection retry
+# ---------------------------------------------------------------------------
+def _run_with_retry(make_coro: Callable[[], Coroutine[Any, Any, Any]]) -> Any:
+    """Run a coroutine on the loop, retrying once after a fresh login.
+
+    A cached client whose token/session has gone stale (process idle, cloud-side
+    session reaped, etc.) surfaces as a GemstoneError. We drop the cache,
+    re-login, and retry exactly once before giving up.
+    """
+    loop = _loop()
+    try:
+        return loop.run(make_coro())
+    except GemstoneError:
+        logger.warning("Gemstone call failed; resetting client and retrying once")
+        loop.run(_reset())
+        return loop.run(make_coro())
+
+
+def get_states() -> dict[str, Any]:
+    """Return current device states plus the saved-pattern catalogue."""
+    return _run_with_retry(_get_states)
+
+
+def apply_action(device_id: str, action: str, value: Any) -> dict[str, Any]:
+    """Apply a single control action and return the refreshed device state."""
+    return _run_with_retry(lambda: _apply_action(device_id, action, value))

--- a/device_control/static/device_control/gemstone.css
+++ b/device_control/static/device_control/gemstone.css
@@ -1,0 +1,104 @@
+/* Gemstone Lights controls. All selectors are scoped under #panel-gemstone so
+   they never collide with the main Device Control stylesheet or the fireplace
+   pane. */
+
+#panel-gemstone * { box-sizing: border-box; }
+
+#panel-gemstone .gem-wrap {
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+    padding: 16px 20px 24px;
+    min-height: calc(100vh - 160px);
+}
+
+#panel-gemstone .gem-status:empty { display: none; }
+
+/* Device card grid */
+#panel-gemstone .gem-devices {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(340px, 1fr));
+    gap: 16px;
+}
+
+#panel-gemstone .gem-card {
+    background: #2a2a2a;
+    border: 1px solid #444;
+    border-radius: 14px;
+    padding: 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    transition: border-color .15s, background .15s;
+}
+#panel-gemstone .gem-card.on { border-color: #7c4dff; background: #262033; }
+
+/* Header: icon + name/status + power */
+#panel-gemstone .gem-head { display: flex; align-items: center; gap: 12px; }
+#panel-gemstone .gem-ic {
+    width: 40px; height: 40px; border-radius: 10px; background: #1f1f1f;
+    display: flex; align-items: center; justify-content: center;
+    font-size: 1.2rem; color: #666; border: 1px solid #3a3a3a; flex-shrink: 0;
+}
+#panel-gemstone .gem-card.on .gem-ic {
+    color: #b39dff; background: #241a33;
+    box-shadow: 0 0 12px rgba(124, 77, 255, .45);
+}
+#panel-gemstone .gem-meta { flex: 1; min-width: 0; }
+#panel-gemstone .gem-meta b { font-size: 1rem; color: #eee; display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+#panel-gemstone .gem-meta span { font-size: .76rem; color: #999; }
+
+#panel-gemstone .dot { font-size: .5rem; vertical-align: middle; margin-right: 5px; }
+#panel-gemstone .dot.online { color: #4caf50; }
+#panel-gemstone .dot.offline { color: #f44336; }
+
+/* Power button */
+#panel-gemstone .gem-power {
+    width: 46px; height: 46px; border-radius: 50%; flex-shrink: 0;
+    background: #1f1f1f; border: 1px solid #444; color: #777;
+    font-size: 1.05rem; cursor: pointer; transition: all .15s;
+}
+#panel-gemstone .gem-power:hover:not(:disabled) { border-color: #7c4dff; color: #b39dff; }
+#panel-gemstone .gem-power.on {
+    background: #7c4dff; border-color: #7c4dff; color: #fff;
+    box-shadow: 0 0 12px rgba(124, 77, 255, .5);
+}
+#panel-gemstone .gem-power:disabled { opacity: .4; cursor: not-allowed; }
+
+/* Current pattern strip */
+#panel-gemstone .gem-current {
+    display: flex; align-items: center; gap: 10px;
+    padding: 8px 10px; background: #1d1d1d; border-radius: 10px; border: 1px solid #383838;
+}
+#panel-gemstone .gem-current > span { font-size: .82rem; color: #ddd; font-weight: 600; }
+
+/* Pattern picker */
+#panel-gemstone .gem-pats {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+    gap: 8px;
+}
+#panel-gemstone .gem-pat {
+    display: flex; flex-direction: column; align-items: stretch; gap: 6px;
+    background: #1f1f1f; border: 1px solid #3a3a3a; border-radius: 10px;
+    padding: 8px; cursor: pointer; text-align: left; transition: all .15s;
+}
+#panel-gemstone .gem-pat:hover:not(:disabled) { border-color: #555; background: #262626; }
+#panel-gemstone .gem-pat.active { border-color: #7c4dff; background: #241a33; box-shadow: 0 0 8px rgba(124, 77, 255, .35); }
+#panel-gemstone .gem-pat:disabled { opacity: .45; cursor: not-allowed; }
+#panel-gemstone .gem-pat-name {
+    font-size: .76rem; color: #ddd; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+#panel-gemstone .gem-pat-name .fa-star { color: #FFD700; font-size: .68rem; }
+
+/* Colour swatches */
+#panel-gemstone .gem-swatches { display: flex; gap: 3px; flex-wrap: nowrap; overflow: hidden; }
+#panel-gemstone .gem-sw { width: 14px; height: 14px; border-radius: 3px; flex-shrink: 0; border: 1px solid rgba(0,0,0,.4); }
+#panel-gemstone .gem-current .gem-sw { width: 16px; height: 16px; }
+
+/* Empty / message states */
+#panel-gemstone .gem-empty { font-size: .8rem; color: #888; padding: 8px 2px; }
+#panel-gemstone .gem-msg {
+    text-align: center; color: #aaa; font-size: 1rem; padding: 60px 20px;
+}
+#panel-gemstone .gem-msg i { margin-right: 8px; color: #7c4dff; }

--- a/device_control/static/device_control/gemstone.js
+++ b/device_control/static/device_control/gemstone.js
@@ -1,0 +1,189 @@
+/* Gemstone Lights controls — power on/off + saved-pattern picker.
+   Wired to the real backend:
+     GET  api/gemstone/states/   -> { configured, devices:[…], patterns:[…] }  (or { configured, error })
+     POST api/gemstone/action/   body { device_id, action, value }  -> { ok, device:{…} }
+
+   The control surface is intentionally small: each discovered device gets a
+   power toggle and a grid of the account's saved patterns; tapping a pattern
+   plays it (and implies power-on). All selectors are scoped under
+   #panel-gemstone. */
+(function () {
+    const ROOT = document.getElementById('panel-gemstone');
+    if (!ROOT) return;  // gemstone tab not present
+
+    const STATES_URL = ROOT.dataset.statesUrl;
+    const ACTION_URL = ROOT.dataset.actionUrl;
+    const CSRF = ROOT.dataset.csrf;
+
+    // raw backend records + transient state
+    let DEVICES = [];
+    let PATTERNS = [];
+    let configured = true;
+    let loadError = null;
+    let editing = false;   // true briefly while an action is in flight
+
+    const sels = {
+        status: ROOT.querySelector('#gemStatus'),
+        devices: ROOT.querySelector('#gemDevices'),
+    };
+
+    // ── helpers ──────────────────────────────────────────────
+    function esc(s) {
+        return String(s == null ? '' : s).replace(/[&<>"']/g, c => ({
+            '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;'
+        }[c]));
+    }
+
+    function swatches(colors, max) {
+        const list = Array.isArray(colors) ? colors.slice(0, max || 10) : [];
+        if (!list.length) return '';
+        return `<div class="gem-swatches">${list.map(c =>
+            `<span class="gem-sw" style="background:${esc(c)}"></span>`).join('')}</div>`;
+    }
+
+    function statusText(d) {
+        if (!d.online) return 'Offline';
+        if (!d.power) return 'Off';
+        return d.pattern_name ? esc(d.pattern_name) : 'On';
+    }
+
+    // ── network ──────────────────────────────────────────────
+    function sendAction(deviceId, action, value) {
+        editing = true;
+        return fetch(ACTION_URL, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json', 'X-CSRFToken': CSRF },
+            body: JSON.stringify({ device_id: deviceId, action, value }),
+        })
+            .then(r => r.json().then(d => ({ ok: r.ok, d })))
+            .then(({ ok, d }) => {
+                if (ok && d && d.device) {
+                    const idx = DEVICES.findIndex(x => x.id === d.device.id);
+                    if (idx >= 0) DEVICES[idx] = d.device;
+                    render();
+                } else if (!ok) {
+                    console.error('gemstone action failed', action, d);
+                }
+            })
+            .catch(err => console.error('gemstone action error', action, err))
+            .finally(() => { editing = false; });
+    }
+
+    function fetchStates() {
+        return fetch(STATES_URL)
+            .then(r => r.json())
+            .then(data => {
+                configured = data.configured !== false;
+                loadError = data.error || null;
+                DEVICES = Array.isArray(data.devices) ? data.devices : [];
+                PATTERNS = Array.isArray(data.patterns) ? data.patterns : [];
+                render();
+            })
+            .catch(err => {
+                console.error('gemstone states error', err);
+                loadError = 'Could not reach the Gemstone service.';
+                render();
+            });
+    }
+
+    // ── render ───────────────────────────────────────────────
+    function showMessage(html) {
+        sels.status.innerHTML = '';
+        sels.devices.innerHTML = `<div class="gem-msg">${html}</div>`;
+    }
+
+    function deviceCard(d) {
+        const online = !!d.online;
+        const on = !!d.power;
+        const dotCls = online ? 'online' : 'offline';
+        const patterns = PATTERNS.map(p => {
+            const active = on && d.pattern_id && p.id === d.pattern_id;
+            return `
+            <button class="gem-pat ${active ? 'active' : ''}" data-pattern="${esc(p.id)}"
+                    title="${esc(p.name)}" ${online ? '' : 'disabled'}>
+                ${swatches(p.colors, 6)}
+                <span class="gem-pat-name">${p.is_favorite ? '<i class="fa-solid fa-star"></i> ' : ''}${esc(p.name)}</span>
+            </button>`;
+        }).join('');
+
+        const patternsBlock = PATTERNS.length
+            ? `<div class="gem-pats">${patterns}</div>`
+            : `<div class="gem-empty">No saved patterns on this account.</div>`;
+
+        return `
+        <div class="gem-card ${on ? 'on' : ''}" data-id="${esc(d.id)}">
+            <div class="gem-head">
+                <div class="gem-ic"><i class="fa-solid fa-gem"></i></div>
+                <div class="gem-meta">
+                    <b>${esc(d.name) || 'Gemstone'}</b>
+                    <span><span class="dot ${dotCls}">●</span>${statusText(d)}</span>
+                </div>
+                <button class="gem-power ${on ? 'on' : ''}" data-power
+                        ${online ? '' : 'disabled'} aria-label="Power">
+                    <i class="fa-solid fa-power-off"></i>
+                </button>
+            </div>
+            ${d.pattern_name && on ? `<div class="gem-current">${swatches(d.pattern_colors, 12)}<span>${esc(d.pattern_name)}</span></div>` : ''}
+            ${patternsBlock}
+        </div>`;
+    }
+
+    function render() {
+        if (!configured) {
+            showMessage('<i class="fa-solid fa-circle-info"></i> Gemstone cloud is not configured. Set GEMSTONE_EMAIL and GEMSTONE_PASSWORD on the server.');
+            return;
+        }
+        if (loadError) {
+            showMessage(`<i class="fa-solid fa-triangle-exclamation"></i> ${esc(loadError)}`);
+            return;
+        }
+        if (!DEVICES.length) {
+            showMessage('<i class="fa-solid fa-gem"></i> No Gemstone devices found on this account.');
+            return;
+        }
+        sels.status.innerHTML = '';
+        sels.devices.innerHTML = DEVICES.map(deviceCard).join('');
+        wire();
+    }
+
+    function wire() {
+        sels.devices.querySelectorAll('.gem-card').forEach(card => {
+            const id = card.dataset.id;
+            const dev = DEVICES.find(x => x.id === id);
+            if (!dev) return;
+
+            const powerBtn = card.querySelector('[data-power]');
+            if (powerBtn) powerBtn.onclick = () => {
+                const next = !dev.power;
+                dev.power = next;            // optimistic
+                render();
+                sendAction(id, 'power', next);
+            };
+
+            card.querySelectorAll('[data-pattern]').forEach(el => el.onclick = () => {
+                const pid = el.dataset.pattern;
+                const pat = PATTERNS.find(p => p.id === pid);
+                dev.power = true;            // playing a pattern implies on
+                dev.pattern_id = pid;
+                if (pat) {
+                    dev.pattern_name = pat.name;
+                    dev.pattern_colors = pat.colors;
+                }
+                render();
+                sendAction(id, 'pattern', pid);
+            });
+        });
+    }
+
+    // ── poll — skip while an action is in flight ─────────────
+    function poll() {
+        if (editing) return;
+        if (!ROOT.classList.contains('active')) return;
+        fetchStates();
+    }
+
+    // initial load + 9s refresh
+    showMessage('<i class="fa-solid fa-spinner fa-spin"></i> Loading Gemstone…');
+    fetchStates();
+    setInterval(poll, 9000);
+})();

--- a/device_control/templates/device_control/device_control.html
+++ b/device_control/templates/device_control/device_control.html
@@ -5,6 +5,7 @@
 
 {% block content %}
 <link rel="stylesheet" href="{% static 'device_control/fireplace.css' %}">
+<link rel="stylesheet" href="{% static 'device_control/gemstone.css' %}">
 <style>
     html, body {
         height: 100%;
@@ -658,6 +659,9 @@
     <div id="panel-{{ tab.key }}" class="dc-panel{% if forloop.first %} active{% endif %}"{% if tab.key == "fireplace" %}
          data-states-url="{% url 'device_control_fireplace_states' %}"
          data-action-url="{% url 'device_control_fireplace_action' %}"
+         data-csrf="{{ csrf_token }}"{% elif tab.key == "gemstone" %}
+         data-states-url="{% url 'device_control_gemstone_states' %}"
+         data-action-url="{% url 'device_control_gemstone_action' %}"
          data-csrf="{{ csrf_token }}"{% endif %}>
         {% if tab.key == "fireplace" %}
         <div class="fp-wrap">
@@ -666,6 +670,11 @@
                 <div class="preview-wrap" id="preview"></div>
             </div>
             <div class="presets-bar" id="presetsBar"></div>
+        </div>
+        {% elif tab.key == "gemstone" %}
+        <div class="gem-wrap">
+            <div class="gem-status" id="gemStatus"></div>
+            <div class="gem-devices" id="gemDevices"></div>
         </div>
         {% else %}
         <div class="dc-loading" id="loading-{{ tab.key }}">
@@ -1378,4 +1387,5 @@
     }
 </script>
 <script src="{% static 'device_control/fireplace.js' %}"></script>
+<script src="{% static 'device_control/gemstone.js' %}"></script>
 {% endblock %}

--- a/device_control/tests.py
+++ b/device_control/tests.py
@@ -403,6 +403,177 @@ class FireplaceTabTests(TestCase):
         self.assertIn('fireplace.css', content)
 
 
+class GemstoneViewTests(TestCase):
+    """Tests for the Gemstone Lights endpoints (mocked gemstone_client)."""
+
+    def _device(self, **over):
+        base = {
+            "id": "dev-123",
+            "name": "Roofline",
+            "online": True,
+            "power": True,
+            "pattern_id": "pat-1",
+            "pattern_name": "Christmas",
+            "pattern_colors": ["#ff0000", "#00ff00"],
+        }
+        base.update(over)
+        return base
+
+    def _pattern(self, **over):
+        base = {
+            "id": "pat-1",
+            "name": "Christmas",
+            "colors": ["#ff0000", "#00ff00"],
+            "is_favorite": True,
+        }
+        base.update(over)
+        return base
+
+    # ----- states endpoint -----
+
+    @patch("device_control.views.gemstone_client.is_configured", return_value=False)
+    def test_states_not_configured(self, _cfg):
+        resp = self.client.get(reverse("device_control_gemstone_states"))
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertFalse(data["configured"])
+        self.assertEqual(data["devices"], [])
+        self.assertEqual(data["patterns"], [])
+
+    @patch("device_control.views.gemstone_client.get_states")
+    @patch("device_control.views.gemstone_client.is_configured", return_value=True)
+    def test_states_success(self, _cfg, mock_states):
+        mock_states.return_value = {
+            "devices": [self._device()],
+            "patterns": [self._pattern()],
+        }
+        resp = self.client.get(reverse("device_control_gemstone_states"))
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertTrue(data["configured"])
+        self.assertEqual(len(data["devices"]), 1)
+        self.assertEqual(data["devices"][0]["id"], "dev-123")
+        self.assertEqual(len(data["patterns"]), 1)
+        self.assertEqual(data["patterns"][0]["id"], "pat-1")
+
+    @patch("device_control.views.gemstone_client.get_states")
+    @patch("device_control.views.gemstone_client.is_configured", return_value=True)
+    def test_states_cloud_error_returns_502(self, _cfg, mock_states):
+        mock_states.side_effect = views.gemstone_client.GemstoneError("cloud down")
+        resp = self.client.get(reverse("device_control_gemstone_states"))
+        self.assertEqual(resp.status_code, 502)
+        data = resp.json()
+        self.assertTrue(data["configured"])
+        self.assertIn("error", data)
+
+    # ----- action endpoint -----
+
+    def test_action_requires_post(self):
+        resp = self.client.get(reverse("device_control_gemstone_action"))
+        self.assertEqual(resp.status_code, 405)
+
+    def test_action_rejects_bad_json(self):
+        resp = self.client.post(
+            reverse("device_control_gemstone_action"),
+            data="not json",
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, 400)
+
+    def test_action_rejects_missing_device_id(self):
+        resp = self.client.post(
+            reverse("device_control_gemstone_action"),
+            data='{"action": "power", "value": true}',
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, 400)
+
+    def test_action_rejects_unknown_action(self):
+        resp = self.client.post(
+            reverse("device_control_gemstone_action"),
+            data='{"device_id": "dev-123", "action": "explode", "value": true}',
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, 400)
+
+    def test_action_rejects_bad_power_value(self):
+        # power must be a bool
+        resp = self.client.post(
+            reverse("device_control_gemstone_action"),
+            data='{"device_id": "dev-123", "action": "power", "value": "on"}',
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, 400)
+
+    def test_action_rejects_empty_pattern(self):
+        resp = self.client.post(
+            reverse("device_control_gemstone_action"),
+            data='{"device_id": "dev-123", "action": "pattern", "value": ""}',
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, 400)
+
+    @patch("device_control.views.gemstone_client.is_configured", return_value=False)
+    def test_action_not_configured_returns_503(self, _cfg):
+        resp = self.client.post(
+            reverse("device_control_gemstone_action"),
+            data='{"device_id": "dev-123", "action": "power", "value": true}',
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, 503)
+
+    @patch("device_control.views.gemstone_client.apply_action")
+    @patch("device_control.views.gemstone_client.is_configured", return_value=True)
+    def test_action_power_success(self, _cfg, mock_apply):
+        mock_apply.return_value = self._device(power=False)
+        resp = self.client.post(
+            reverse("device_control_gemstone_action"),
+            data='{"device_id": "dev-123", "action": "power", "value": false}',
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertTrue(data["ok"])
+        self.assertFalse(data["device"]["power"])
+        mock_apply.assert_called_once_with("dev-123", "power", False)
+
+    @patch("device_control.views.gemstone_client.apply_action")
+    @patch("device_control.views.gemstone_client.is_configured", return_value=True)
+    def test_action_pattern_success(self, _cfg, mock_apply):
+        mock_apply.return_value = self._device(pattern_id="pat-2", pattern_name="Halloween")
+        resp = self.client.post(
+            reverse("device_control_gemstone_action"),
+            data='{"device_id": "dev-123", "action": "pattern", "value": "pat-2"}',
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, 200)
+        mock_apply.assert_called_once_with("dev-123", "pattern", "pat-2")
+
+    @patch("device_control.views.gemstone_client.apply_action")
+    @patch("device_control.views.gemstone_client.is_configured", return_value=True)
+    def test_action_cloud_error_returns_502(self, _cfg, mock_apply):
+        mock_apply.side_effect = views.gemstone_client.GemstoneError("timeout")
+        resp = self.client.post(
+            reverse("device_control_gemstone_action"),
+            data='{"device_id": "dev-123", "action": "power", "value": true}',
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, 502)
+        self.assertFalse(resp.json()["ok"])
+
+
+class GemstoneTabTests(TestCase):
+    """The gemstone tab must render its dedicated panel structure."""
+
+    def test_gemstone_panel_rendered(self):
+        resp = self.client.get(reverse("device_control"))
+        content = resp.content.decode()
+        self.assertIn('id="panel-gemstone"', content)
+        self.assertIn('id="gemDevices"', content)
+        self.assertIn('gemstone.js', content)
+        self.assertIn('gemstone.css', content)
+
+
 @tag('selenium')
 class DeviceControlShadesSliderTest(StaticLiveServerTestCase):
     """Ensure shade cards render a position slider that fits within the card."""

--- a/device_control/urls.py
+++ b/device_control/urls.py
@@ -7,4 +7,6 @@ urlpatterns = [
     path('api/action/', views.device_control_action, name='device_control_action'),
     path('api/fireplace/states/', views.device_control_fireplace_states, name='device_control_fireplace_states'),
     path('api/fireplace/action/', views.device_control_fireplace_action, name='device_control_fireplace_action'),
+    path('api/gemstone/states/', views.device_control_gemstone_states, name='device_control_gemstone_states'),
+    path('api/gemstone/action/', views.device_control_gemstone_action, name='device_control_gemstone_action'),
 ]

--- a/device_control/views.py
+++ b/device_control/views.py
@@ -14,9 +14,10 @@ from django.http import JsonResponse
 from django.shortcuts import render
 from django.views.decorators.http import require_POST
 
-from .device_config import TABS, get_all_entity_ids, FIREPLACE_OVERRIDES
+from .device_config import TABS, get_all_entity_ids, FIREPLACE_OVERRIDES, GEMSTONE_OVERRIDES
 from .ha_client import call_service, get_entity_states
 from . import napoleon_client
+from . import gemstone_client
 
 logger = logging.getLogger(__name__)
 
@@ -242,3 +243,91 @@ def device_control_fireplace_action(request):
         return JsonResponse({"ok": False, "error": str(exc)}, status=502)
 
     return JsonResponse({"ok": True, "fireplace": _apply_overrides(state)})
+
+
+# ──────────────────────────────────────────────
+# Gemstone Lights (cloud) endpoints
+# ──────────────────────────────────────────────
+# These bypass Home Assistant entirely and talk to the Gemstone Lights cloud
+# through device_control.gemstone_client. The control surface is intentionally
+# small: power on/off and selecting one of the user's saved patterns.
+
+# Action -> validator for the supplied value. Anything not listed is rejected.
+_GEMSTONE_ACTION_VALIDATORS = {
+    "power": lambda v: isinstance(v, bool),
+    "pattern": lambda v: isinstance(v, str) and bool(v),
+}
+
+
+def _apply_gemstone_overrides(state):
+    """Apply optional name/room overrides from device_config to a state dict."""
+    override = GEMSTONE_OVERRIDES.get(state.get("id"))
+    if override:
+        if override.get("name"):
+            state["name"] = override["name"]
+        if override.get("room"):
+            state["room"] = override["room"]
+    return state
+
+
+def device_control_gemstone_states(request):
+    """AJAX endpoint: current state of every Gemstone device + saved patterns.
+
+    Returns JSON: { "configured": bool, "devices": [...], "patterns": [...] }
+    """
+    if not gemstone_client.is_configured():
+        return JsonResponse({"configured": False, "devices": [], "patterns": []})
+
+    try:
+        data = gemstone_client.get_states()
+    except gemstone_client.GemstoneError as exc:
+        logger.warning("Gemstone states fetch failed: %s", exc)
+        return JsonResponse({"configured": True, "error": str(exc)}, status=502)
+
+    devices = [_apply_gemstone_overrides(d) for d in data.get("devices", [])]
+    return JsonResponse(
+        {
+            "configured": True,
+            "devices": devices,
+            "patterns": data.get("patterns", []),
+        }
+    )
+
+
+@require_POST
+def device_control_gemstone_action(request):
+    """AJAX endpoint: apply a control action to a Gemstone device.
+
+    Expects JSON body: { device_id, action, value }
+    Returns the refreshed device state on success.
+    """
+    try:
+        body = json.loads(request.body)
+    except (json.JSONDecodeError, ValueError):
+        return JsonResponse({"error": "Invalid JSON"}, status=400)
+
+    device_id = body.get("device_id", "")
+    action = body.get("action", "")
+    value = body.get("value")
+
+    if not device_id:
+        return JsonResponse({"error": "Missing device_id"}, status=400)
+
+    validator = _GEMSTONE_ACTION_VALIDATORS.get(action)
+    if validator is None:
+        return JsonResponse({"error": f"Unknown action: {action}"}, status=400)
+    if not validator(value):
+        return JsonResponse(
+            {"error": f"Invalid value for {action}: {value!r}"}, status=400
+        )
+
+    if not gemstone_client.is_configured():
+        return JsonResponse({"error": "Gemstone not configured"}, status=503)
+
+    try:
+        state = gemstone_client.apply_action(device_id, action, value)
+    except gemstone_client.GemstoneError as exc:
+        logger.warning("Gemstone action %s failed: %s", action, exc)
+        return JsonResponse({"ok": False, "error": str(exc)}, status=502)
+
+    return JsonResponse({"ok": True, "device": _apply_gemstone_overrides(state)})

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,6 +56,10 @@ services:
       NAPOLEON_PASSWORD: ${NAPOLEON_PASSWORD}
       NAPOLEON_EUROPE: ${NAPOLEON_EUROPE}
 
+      # Gemstone Lights (AWS Amplify cloud)
+      GEMSTONE_EMAIL: ${GEMSTONE_EMAIL}
+      GEMSTONE_PASSWORD: ${GEMSTONE_PASSWORD}
+
     network_mode: host
     
     restart: unless-stopped

--- a/requirements.txt
+++ b/requirements.txt
@@ -80,3 +80,4 @@ python-dateutil
 pytz
 websockets
 pynapoleon==0.0.2
+pygemstone==0.0.2


### PR DESCRIPTION
## Summary

Adds a new **Gemstone** tab to the `device_control` app for controlling Gemstone permanent lights via the async `pygemstone` cloud library.

**Control surface:** per-device power on/off + saved-pattern selection.

Mirrors the existing Napoleon Fireplace tab architecture (dedicated asyncio loop thread bridging sync Django views to the async cloud client; self-managed frontend panel with its own polling).

## Changes

- `gemstone_client.py` (NEW) — sync→async bridge: `gemstone-loop` thread, cached logged-in `GemstoneClient`, pattern discovery via `folder_patterns`, `is_configured()` / `get_states()` / `apply_action()` + auth-retry.
- `views.py` — `device_control_gemstone_states` (GET) and `device_control_gemstone_action` (POST) with action validators (`power`: bool, `pattern`: non-empty str).
- `urls.py` — `api/gemstone/states/` and `api/gemstone/action/`.
- `device_config.py` — `GEMSTONE_OVERRIDES` + gemstone tab in `TABS`.
- `settings.py` / `.env.example` / `docker-compose.yml` — `GEMSTONE_EMAIL` / `GEMSTONE_PASSWORD` wiring.
- `requirements.txt` — `pygemstone==0.0.2`.
- `gemstone.js` / `gemstone.css` (NEW) — scoped panel (device cards + pattern grid, purple accent).
- `tests.py` — `GemstoneViewTests` + `GemstoneTabTests` (mocked client).

## Deploy / follow-up

- Existing HA path and Fireplace tab are untouched.
- Credentials (`GEMSTONE_EMAIL` / `GEMSTONE_PASSWORD`) are not set in any env yet — the tab shows a "not configured" message until they're added on homehub after this lands.

## Validation

- `py_compile` on all touched Python — OK
- `node --check gemstone.js` — OK
- `pygemstone.errors` import path confirmed against the library
- Full unit + selenium suite runs in CI.
