### PR TITLE
Gemstone tab: device selector + dynamic preset grid

### DIFF
--- a/device_control/static/device_control/gemstone.css
+++ b/device_control/static/device_control/gemstone.css
@@ -14,13 +14,39 @@
 
 #panel-gemstone .gem-status:empty { display: none; }
 
-/* Device card grid */
-#panel-gemstone .gem-devices {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(340px, 1fr));
-    gap: 16px;
+/* Device selector pills (one per Gemstone system, shown only when >1 device) */
+#panel-gemstone .gem-select {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
 }
+#panel-gemstone .gem-select:empty { display: none; }
 
+#panel-gemstone .gem-pill {
+    display: flex; align-items: center; gap: 10px;
+    background: #2a2a2a; border: 1px solid #444; border-radius: 12px;
+    padding: 10px 16px 10px 12px; cursor: pointer; min-width: 200px;
+    transition: border-color .15s, background .15s;
+}
+#panel-gemstone .gem-pill:hover { border-color: #555; background: #2f2f2f; }
+#panel-gemstone .gem-pill.active {
+    border-color: #7c4dff; background: #262033;
+    box-shadow: 0 0 10px rgba(124, 77, 255, .3);
+}
+#panel-gemstone .gem-pill .pill-ic {
+    width: 34px; height: 34px; border-radius: 9px; background: #1f1f1f;
+    display: flex; align-items: center; justify-content: center;
+    font-size: 1.05rem; color: #666; border: 1px solid #3a3a3a; flex-shrink: 0;
+}
+#panel-gemstone .gem-pill.on .pill-ic {
+    color: #b39dff; background: #241a33;
+    box-shadow: 0 0 10px rgba(124, 77, 255, .4);
+}
+#panel-gemstone .gem-pill .pill-txt { min-width: 0; }
+#panel-gemstone .gem-pill .pill-txt b { font-size: .92rem; color: #eee; display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+#panel-gemstone .gem-pill .pill-txt span { font-size: .72rem; color: #999; }
+
+/* Selected device detail card (full width) */
 #panel-gemstone .gem-card {
     background: #2a2a2a;
     border: 1px solid #444;
@@ -28,7 +54,7 @@
     padding: 16px;
     display: flex;
     flex-direction: column;
-    gap: 12px;
+    gap: 14px;
     transition: border-color .15s, background .15s;
 }
 #panel-gemstone .gem-card.on { border-color: #7c4dff; background: #262033; }
@@ -72,10 +98,10 @@
 }
 #panel-gemstone .gem-current > span { font-size: .82rem; color: #ddd; font-weight: 600; }
 
-/* Pattern picker */
+/* Pattern picker — dynamic columns (~8 on a 1920px display) */
 #panel-gemstone .gem-pats {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
     gap: 8px;
 }
 #panel-gemstone .gem-pat {

--- a/device_control/static/device_control/gemstone.js
+++ b/device_control/static/device_control/gemstone.js
@@ -3,10 +3,10 @@
      GET  api/gemstone/states/   -> { configured, devices:[…], patterns:[…] }  (or { configured, error })
      POST api/gemstone/action/   body { device_id, action, value }  -> { ok, device:{…} }
 
-   The control surface is intentionally small: each discovered device gets a
-   power toggle and a grid of the account's saved patterns; tapping a pattern
-   plays it (and implies power-on). All selectors are scoped under
-   #panel-gemstone. */
+   Layout: a row of device-selector pills (one per discovered Gemstone system).
+   Selecting a device exposes its power toggle and a dense, dynamically-columned
+   grid of the account's saved patterns; tapping a pattern plays it (and implies
+   power-on). All selectors are scoped under #panel-gemstone. */
 (function () {
     const ROOT = document.getElementById('panel-gemstone');
     if (!ROOT) return;  // gemstone tab not present
@@ -21,10 +21,12 @@
     let configured = true;
     let loadError = null;
     let editing = false;   // true briefly while an action is in flight
+    let sel = 0;           // index of the currently-selected device
 
     const sels = {
         status: ROOT.querySelector('#gemStatus'),
-        devices: ROOT.querySelector('#gemDevices'),
+        select: ROOT.querySelector('#gemSelect'),
+        detail: ROOT.querySelector('#gemDetail'),
     };
 
     // ── helpers ──────────────────────────────────────────────
@@ -89,19 +91,38 @@
     // ── render ───────────────────────────────────────────────
     function showMessage(html) {
         sels.status.innerHTML = '';
-        sels.devices.innerHTML = `<div class="gem-msg">${html}</div>`;
+        sels.select.innerHTML = '';
+        sels.detail.innerHTML = `<div class="gem-msg">${html}</div>`;
     }
 
-    function deviceCard(d) {
+    function renderSelect() {
+        // A single device needs no picker — go straight to its presets.
+        if (DEVICES.length <= 1) { sels.select.innerHTML = ''; return; }
+        sels.select.innerHTML = DEVICES.map((d, i) => {
+            const on = !!d.power;
+            return `
+            <div class="gem-pill ${on ? 'on' : ''} ${i === sel ? 'active' : ''}" data-sel="${i}">
+                <div class="pill-ic"><i class="fa-solid fa-gem"></i></div>
+                <div class="pill-txt">
+                    <b>${esc(d.name) || 'Gemstone'}</b>
+                    <span><span class="dot ${d.online ? 'online' : 'offline'}">●</span>${statusText(d)}</span>
+                </div>
+            </div>`;
+        }).join('');
+    }
+
+    function renderDetail() {
+        const d = DEVICES[sel];
+        if (!d) { sels.detail.innerHTML = ''; return; }
         const online = !!d.online;
         const on = !!d.power;
-        const dotCls = online ? 'online' : 'offline';
+
         const patterns = PATTERNS.map(p => {
             const active = on && d.pattern_id && p.id === d.pattern_id;
             return `
             <button class="gem-pat ${active ? 'active' : ''}" data-pattern="${esc(p.id)}"
                     title="${esc(p.name)}" ${online ? '' : 'disabled'}>
-                ${swatches(p.colors, 6)}
+                ${swatches(p.colors, 8)}
                 <span class="gem-pat-name">${p.is_favorite ? '<i class="fa-solid fa-star"></i> ' : ''}${esc(p.name)}</span>
             </button>`;
         }).join('');
@@ -110,20 +131,20 @@
             ? `<div class="gem-pats">${patterns}</div>`
             : `<div class="gem-empty">No saved patterns on this account.</div>`;
 
-        return `
+        sels.detail.innerHTML = `
         <div class="gem-card ${on ? 'on' : ''}" data-id="${esc(d.id)}">
             <div class="gem-head">
                 <div class="gem-ic"><i class="fa-solid fa-gem"></i></div>
                 <div class="gem-meta">
                     <b>${esc(d.name) || 'Gemstone'}</b>
-                    <span><span class="dot ${dotCls}">●</span>${statusText(d)}</span>
+                    <span><span class="dot ${online ? 'online' : 'offline'}">●</span>${statusText(d)}</span>
                 </div>
+                ${d.pattern_name && on ? `<div class="gem-current">${swatches(d.pattern_colors, 12)}<span>${esc(d.pattern_name)}</span></div>` : ''}
                 <button class="gem-power ${on ? 'on' : ''}" data-power
                         ${online ? '' : 'disabled'} aria-label="Power">
                     <i class="fa-solid fa-power-off"></i>
                 </button>
             </div>
-            ${d.pattern_name && on ? `<div class="gem-current">${swatches(d.pattern_colors, 12)}<span>${esc(d.pattern_name)}</span></div>` : ''}
             ${patternsBlock}
         </div>`;
     }
@@ -141,37 +162,44 @@
             showMessage('<i class="fa-solid fa-gem"></i> No Gemstone devices found on this account.');
             return;
         }
+        if (sel >= DEVICES.length) sel = 0;
         sels.status.innerHTML = '';
-        sels.devices.innerHTML = DEVICES.map(deviceCard).join('');
+        renderSelect();
+        renderDetail();
         wire();
     }
 
     function wire() {
-        sels.devices.querySelectorAll('.gem-card').forEach(card => {
-            const id = card.dataset.id;
-            const dev = DEVICES.find(x => x.id === id);
-            if (!dev) return;
+        sels.select.querySelectorAll('[data-sel]').forEach(el => el.onclick = () => {
+            sel = +el.dataset.sel;
+            render();
+        });
 
-            const powerBtn = card.querySelector('[data-power]');
-            if (powerBtn) powerBtn.onclick = () => {
-                const next = !dev.power;
-                dev.power = next;            // optimistic
-                render();
-                sendAction(id, 'power', next);
-            };
+        const card = sels.detail.querySelector('.gem-card');
+        if (!card) return;
+        const id = card.dataset.id;
+        const dev = DEVICES.find(x => x.id === id);
+        if (!dev) return;
 
-            card.querySelectorAll('[data-pattern]').forEach(el => el.onclick = () => {
-                const pid = el.dataset.pattern;
-                const pat = PATTERNS.find(p => p.id === pid);
-                dev.power = true;            // playing a pattern implies on
-                dev.pattern_id = pid;
-                if (pat) {
-                    dev.pattern_name = pat.name;
-                    dev.pattern_colors = pat.colors;
-                }
-                render();
-                sendAction(id, 'pattern', pid);
-            });
+        const powerBtn = card.querySelector('[data-power]');
+        if (powerBtn) powerBtn.onclick = () => {
+            const next = !dev.power;
+            dev.power = next;            // optimistic
+            render();
+            sendAction(id, 'power', next);
+        };
+
+        card.querySelectorAll('[data-pattern]').forEach(el => el.onclick = () => {
+            const pid = el.dataset.pattern;
+            const pat = PATTERNS.find(p => p.id === pid);
+            dev.power = true;            // playing a pattern implies on
+            dev.pattern_id = pid;
+            if (pat) {
+                dev.pattern_name = pat.name;
+                dev.pattern_colors = pat.colors;
+            }
+            render();
+            sendAction(id, 'pattern', pid);
         });
     }
 

--- a/device_control/templates/device_control/device_control.html
+++ b/device_control/templates/device_control/device_control.html
@@ -674,7 +674,8 @@
         {% elif tab.key == "gemstone" %}
         <div class="gem-wrap">
             <div class="gem-status" id="gemStatus"></div>
-            <div class="gem-devices" id="gemDevices"></div>
+            <div class="gem-select" id="gemSelect"></div>
+            <div class="gem-detail" id="gemDetail"></div>
         </div>
         {% else %}
         <div class="dc-loading" id="loading-{{ tab.key }}">

--- a/device_control/tests.py
+++ b/device_control/tests.py
@@ -569,7 +569,8 @@ class GemstoneTabTests(TestCase):
         resp = self.client.get(reverse("device_control"))
         content = resp.content.decode()
         self.assertIn('id="panel-gemstone"', content)
-        self.assertIn('id="gemDevices"', content)
+        self.assertIn('id="gemSelect"', content)
+        self.assertIn('id="gemDetail"', content)
         self.assertIn('gemstone.js', content)
         self.assertIn('gemstone.css', content)
 


### PR DESCRIPTION
Redesign the Gemstone Lights tab to mirror the fireplace device-selector UX.

**Selector:** a row of device pills (one per Gemstone system, hidden when only one device) replaces the all-at-once card grid. Click a device to expose its power toggle and preset grid.

**Dynamic columns:** the saved-pattern grid now uses uto-fill / minmax(200px, 1fr) — ~8 columns on a 1920px display instead of the old fixed 2-wide layout.

- template: \gemSelect\ + \gemDetail\ replace \gemDevices\
- gemstone.js: per-device \sel\ index; \ender()\ split into \enderSelect()\ / \enderDetail()\; optimistic updates + polling preserved
- gemstone.css: new \.gem-select\/\.gem-pill\; full-width detail card; dynamic pattern grid
- tests: GemstoneTabTests asserts new ids

Backend untouched. Validated: \
ode --check gemstone.js\, \py_compile tests.py\.