### PR TITLE
Fix Gemstone swatch colours (R/B byte-swap)

### DIFF
--- a/device_control/gemstone_client.py
+++ b/device_control/gemstone_client.py
@@ -107,12 +107,29 @@ def is_configured() -> bool:
 
 
 def _color_to_hex(c: Any) -> str:
-    """Best-effort conversion of a packed integer colour to ``#rrggbb``."""
+    """Convert a Gemstone packed integer colour to a CSS ``#rrggbb`` string.
+
+    Gemstone packs colours little-endian with **red in the lowest byte**
+    (``0xWWBBGGRR``), not ``0xRRGGBB``. e.g. the cloud's "Red" swatch is the
+    int ``255`` (``0x000000FF``) and "Green" is ``65280`` (``0x0000FF00``).
+    So we read R from the low byte and B from the third byte and swap them
+    into standard ``#rrggbb`` for the browser.
+
+    The top byte is a dedicated white-LED channel (RGBW strips). When it is
+    set while RGB is zero (e.g. "Warm White" == ``0xFF000000``) there is no
+    true RGB value, so we render a warm-white approximation for display.
+    """
     try:
         n = int(c)
     except (TypeError, ValueError):
         return "#000000"
-    return "#%06x" % (n & 0xFFFFFF)
+    r = n & 0xFF
+    g = (n >> 8) & 0xFF
+    b = (n >> 16) & 0xFF
+    w = (n >> 24) & 0xFF
+    if w and not (r or g or b):
+        return "#fff1e0"
+    return "#%02x%02x%02x" % (r, g, b)
 
 
 async def _ensure_client() -> None:

--- a/device_control/tests.py
+++ b/device_control/tests.py
@@ -575,6 +575,29 @@ class GemstoneTabTests(TestCase):
         self.assertIn('gemstone.css', content)
 
 
+class GemstoneColorDecodeTests(TestCase):
+    """``_color_to_hex`` must honour Gemstone's little-endian (R-low) packing."""
+
+    def test_known_fixture_colors(self):
+        from .gemstone_client import _color_to_hex
+        # Values + names taken from pygemstone's own test fixtures.
+        self.assertEqual(_color_to_hex(255), "#ff0000")        # "Red"  0x000000FF
+        self.assertEqual(_color_to_hex(65280), "#00ff00")      # "Green" 0x0000FF00
+        self.assertEqual(_color_to_hex(16711680), "#0000ff")   # blue   0x00FF0000
+        self.assertEqual(_color_to_hex(16777215), "#ffffff")   # "Cool White" 0x00FFFFFF
+        self.assertEqual(_color_to_hex(4294967295), "#ffffff")  # white w/ alpha
+
+    def test_warm_white_channel(self):
+        from .gemstone_client import _color_to_hex
+        # White-LED channel sentinel (0xFF000000): no RGB, render warm white.
+        self.assertEqual(_color_to_hex(4278190080), "#fff1e0")
+
+    def test_bad_input_falls_back(self):
+        from .gemstone_client import _color_to_hex
+        self.assertEqual(_color_to_hex(None), "#000000")
+        self.assertEqual(_color_to_hex("nope"), "#000000")
+
+
 @tag('selenium')
 class DeviceControlShadesSliderTest(StaticLiveServerTestCase):
     """Ensure shade cards render a position slider that fits within the card."""


### PR DESCRIPTION
Gemstone packs colours little-endian (red in the low byte, `0xWWBBGGRR`), but `_color_to_hex` decoded the low 24 bits as `0xRRGGBB` — so red (int `255`) rendered as CSS blue. Symmetric colours like white were unaffected, which masked the bug (e.g. the 'all Red 2white' pattern showed white right, red as blue).

## Fix
- Read R from the low byte, B from the third byte, emit standard `#rrggbb`.
- Handle the RGBW white-channel sentinel (`0xFF000000` = 'Warm White') as a warm-white approximation instead of black.

## Tests
`GemstoneColorDecodeTests` validates against pygemstone's own fixture values (255->Red `#ff0000`, 65280->Green `#00ff00`, etc.).

Library is unchanged — pygemstone correctly passes raw ints through; the decode bug was entirely on the BlackDiamondHub side.