### PR TITLE
Use pygemstone color helpers in Gemstone device control

### DIFF
--- a/device_control/gemstone_client.py
+++ b/device_control/gemstone_client.py
@@ -109,27 +109,24 @@ def is_configured() -> bool:
 def _color_to_hex(c: Any) -> str:
     """Convert a Gemstone packed integer colour to a CSS ``#rrggbb`` string.
 
-    Gemstone packs colours little-endian with **red in the lowest byte**
-    (``0xWWBBGGRR``), not ``0xRRGGBB``. e.g. the cloud's "Red" swatch is the
-    int ``255`` (``0x000000FF``) and "Green" is ``65280`` (``0x0000FF00``).
-    So we read R from the low byte and B from the third byte and swap them
-    into standard ``#rrggbb`` for the browser.
-
-    The top byte is a dedicated white-LED channel (RGBW strips). When it is
-    set while RGB is zero (e.g. "Warm White" == ``0xFF000000``) there is no
-    true RGB value, so we render a warm-white approximation for display.
+    Delegates to :mod:`pygemstone`'s colour helpers, which document the
+    little-endian ``0xWWBBGGRR`` byte layout (red in the low byte, with a
+    dedicated white-LED channel in the top byte for RGBW strips). pygemstone's
+    :func:`color_to_hex` intentionally drops the white channel, so for the
+    warm-white sentinel (white channel set while RGB is zero, e.g. "Warm
+    White" == ``0xFF000000``) we render a warm-white approximation instead of
+    the black that the raw RGB would produce.
     """
+    from pygemstone import color_to_hex, unpack_color
+    from pygemstone.errors import GemstoneValueError
+
     try:
-        n = int(c)
-    except (TypeError, ValueError):
+        r, g, b, w = unpack_color(c)
+    except (GemstoneValueError, TypeError, ValueError):
         return "#000000"
-    r = n & 0xFF
-    g = (n >> 8) & 0xFF
-    b = (n >> 16) & 0xFF
-    w = (n >> 24) & 0xFF
     if w and not (r or g or b):
         return "#fff1e0"
-    return "#%02x%02x%02x" % (r, g, b)
+    return color_to_hex(c)
 
 
 async def _ensure_client() -> None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -80,4 +80,4 @@ python-dateutil
 pytz
 websockets
 pynapoleon==0.0.2
-pygemstone==0.0.2
+pygemstone==0.0.3


### PR DESCRIPTION
Replaces the inline R/B byte-swap logic in `_color_to_hex` with delegation to pygemstone 0.0.3's new `unpack_color` / `color_to_hex` helpers, which document the little-endian `0xWWBBGGRR` layout so byte order is no longer guesswork.

- Bumps pin `pygemstone==0.0.2` -> `0.0.3`.
- Behaviour unchanged: warm-white sentinel still renders `#fff1e0`; verified against all cloud ground-truth swatches (Red/Green/Blue/CoolWhite/WarmWhite/White + bad input).
- Existing `GemstoneColorDecodeTests` continue to apply.