### PR TITLE
Fix laggy Gemstone power toggle (stale-refresh revert)

### DIFF
--- a/device_control/gemstone_client.py
+++ b/device_control/gemstone_client.py
@@ -285,11 +285,38 @@ async def _apply_action(device_id: str, action: str, value: Any) -> dict[str, An
 
     try:
         await handler(dev, value)
-        # Reflect the change back to the caller.
-        await dev.refresh()
     except LibGemstoneError as exc:
         raise GemstoneError(f"{action} failed: {exc}") from exc
-    return _state_to_dict(dev)
+
+    # Return an OPTIMISTIC state built from the last-known cached state plus the
+    # change we just requested. We deliberately do NOT call ``dev.refresh()``
+    # here: the Gemstone cloud is eventually-consistent, so a refresh issued
+    # immediately after a toggle very often returns the *pre-toggle* state. That
+    # stale value would clobber the UI's optimistic flip and make the button
+    # look like it "did nothing for a bit". The periodic poll (``_get_states``)
+    # reconciles authoritative state a few seconds later.
+    return _optimistic_state(dev, action, value)
+
+
+def _optimistic_state(dev: Any, action: str, value: Any) -> dict[str, Any]:
+    """Last-known cached state, overlaid with the change we just requested."""
+    base = _state_to_dict(dev)
+    if action == "power":
+        base["power"] = bool(value)
+        if not base["power"]:
+            base["pattern_id"] = None
+            base["pattern_name"] = None
+            base["pattern_colors"] = []
+    elif action == "pattern":
+        base["power"] = True
+        pat = _patterns_by_id.get(str(value))
+        if pat is not None:
+            base["pattern_id"] = getattr(pat, "id", None)
+            base["pattern_name"] = getattr(pat, "name", None)
+            base["pattern_colors"] = [
+                _color_to_hex(c) for c in (getattr(pat, "colors", None) or [])
+            ]
+    return base
 
 
 # ---------------------------------------------------------------------------

--- a/device_control/static/device_control/gemstone.js
+++ b/device_control/static/device_control/gemstone.js
@@ -68,7 +68,7 @@
                 }
             })
             .catch(err => console.error('gemstone action error', action, err))
-            .finally(() => { editing = false; });
+            .finally(() => { editing = false; render(); });
     }
 
     function fetchStates() {
@@ -186,6 +186,9 @@
             const next = !dev.power;
             dev.power = next;            // optimistic
             render();
+            // Show the click registered while the cloud round-trip is in flight.
+            const b = sels.detail.querySelector('[data-power]');
+            if (b) { b.disabled = true; b.innerHTML = '<i class="fa-solid fa-spinner fa-spin"></i>'; }
             sendAction(id, 'power', next);
         };
 


### PR DESCRIPTION
## Problem
Toggling the Gemstone power button "did nothing for a bit" — both on and off.

## Root cause
The frontend already flips the button optimistically on click, but the backend `_apply_action` did a **second** sequential cloud round-trip — `dev.refresh()` — right after `turn_on()`/`turn_off()`. The Gemstone (AWS) cloud is eventually-consistent, so that immediate refresh frequently returned the **pre-toggle** state. `sendAction` then wrote that stale value back over the optimistic flip, so the button visually reverted and only corrected on a later 9s poll.

## Fix
- **Backend** (`gemstone_client.py`): for `power`/`pattern` actions, return an **optimistic** state assembled from the last-known cached state + the change just requested, instead of a stale `refresh()`. Removes the second round-trip (halves action latency) and the revert. The periodic `_get_states` poll reconciles authoritative state a few seconds later.
- **Frontend** (`gemstone.js`): show a spinner on the power button while the request is in flight, and always re-render in `sendAction`'s `finally` so the button recovers even if the action fails.

## Validation
- `py_compile` (backend) + `node --check` (frontend) pass.
- Existing view tests mock `apply_action` at the view boundary, so internal change is unaffected.
