### PR TITLE
Add seasonal heating/cooling support to vacation mode

### DIFF
--- a/BlackDiamondHub/settings_test.py
+++ b/BlackDiamondHub/settings_test.py
@@ -1,0 +1,15 @@
+"""
+Test-only settings override: run the Django test suite against an in-memory
+SQLite database so tests don't require a live PostgreSQL server.
+
+Usage:
+    python manage.py test vacation_mode --settings=BlackDiamondHub.settings_test
+"""
+from .settings import *  # noqa: F401,F403
+
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": ":memory:",
+    }
+}

--- a/vacation_mode/executor.py
+++ b/vacation_mode/executor.py
@@ -35,6 +35,12 @@ STATUS_SUCCESS = "success"
 STATUS_FAILED = "failed"
 STATUS_SKIPPED = "skipped"
 
+# Season selection: the AECO changeover (heating vs cooling) is chosen from the
+# daily-average outdoor temperature. At/above the threshold we cool, below it we
+# heat. On any error we default to heating (the freeze-safe mode).
+SEASON_OUTDOOR_AVG_ENTITY = "sensor.hvac_load_shift_metrics_outdoor_avg_day"
+SEASON_THRESHOLD_C = 15.0
+
 
 def get_ha_headers():
     """Get authorization headers for Home Assistant API."""
@@ -63,6 +69,36 @@ def get_away_mode_state():
     except requests.RequestException as e:
         logger.error(f"Failed to query away mode state: {e}")
     return False
+
+
+def get_current_season():
+    """
+    Decide the seasonal HVAC mode from the daily-average outdoor temperature.
+
+    Returns:
+        (season, avg) where season is "cooling" or "heating" and avg is the
+        outdoor daily-average temperature in °C (or None if it couldn't be
+        read). On any error we default to "heating" — the freeze-safe mode.
+    """
+    from .steps import SEASON_HEATING, SEASON_COOLING
+
+    url = urljoin(get_ha_base_url(), f"/api/states/{SEASON_OUTDOOR_AVG_ENTITY}")
+    try:
+        response = requests.get(url, headers=get_ha_headers(), timeout=10)
+        if response.status_code == 200:
+            avg = float(response.json().get("state"))
+            season = SEASON_COOLING if avg >= SEASON_THRESHOLD_C else SEASON_HEATING
+            logger.info(
+                f"Season decision: outdoor daily avg {avg}°C "
+                f"(threshold {SEASON_THRESHOLD_C}°C) → {season}"
+            )
+            return season, avg
+        logger.warning(
+            f"Season sensor returned HTTP {response.status_code}; defaulting to heating"
+        )
+    except (requests.RequestException, ValueError, TypeError) as e:
+        logger.warning(f"Failed to read season sensor ({e}); defaulting to heating")
+    return SEASON_HEATING, None
 
 
 def resolve_entity_id(device_id, domain, action_data):
@@ -452,18 +488,24 @@ def start_execution(mode, dry_run=False, skip_steps=None):
     Returns:
         (run_id, error_message) - error_message is None on success
     """
-    from .steps import VACATION_STEPS, HOME_STEPS
+    from .steps import build_vacation_steps, build_home_steps
 
     if not _execution_lock.acquire(blocking=False):
         return None, "An execution is already in progress"
 
-    steps = VACATION_STEPS if mode == "vacation" else HOME_STEPS
+    season, season_avg = get_current_season()
+    if mode == "vacation":
+        steps = build_vacation_steps(season)
+    else:
+        steps = build_home_steps(season)
     skip_set = set(skip_steps) if skip_steps else set()
     run_id = str(uuid.uuid4())[:8]
 
     _runs[run_id] = {
         "run_id": run_id,
         "mode": mode,
+        "season": season,
+        "season_avg": season_avg,
         "dry_run": dry_run,
         "status": "running",
         "started_at": time.time(),

--- a/vacation_mode/steps.py
+++ b/vacation_mode/steps.py
@@ -9,587 +9,647 @@ Each step is a dict with:
     - action: HA service to call (e.g. "climate/set_temperature")
     - data: Payload to send
     - delay_after: Optional delay in seconds after this action
+
+Seasonal behaviour
+------------------
+The AECO-1988 heat pump is a changeover system: it produces EITHER hot water
+(heating the buffer/floors) OR chilled water (cooling the floors), never both.
+The active mode is selected by the mutually-exclusive permanent-demand switches
+(``switch.aeco_1988_permanent_heat_demand`` / ``permanent_cool_demand``) — the
+``heat/cool/auto`` select is not used. While in one mode, the OTHER tank's
+number entities (min/max/target/outdoor_reset) report ``unavailable``, so the
+mode must be flipped (and given a few seconds to settle) BEFORE its tank
+entities can be written.
+
+Because of this, the HVAC steps are built per-season. ``build_vacation_steps``
+and ``build_home_steps`` take a ``season`` ("heating" or "cooling"); the season
+is chosen at run time from the daily-average outdoor temperature (see
+``executor.get_current_season``). Everything else (water heater, hot tub, TVs,
+fridge/freezer, garage) is season-independent.
+
+The zone thermostats are Google Nest units and are rate-limited, so each
+``climate/set_temperature`` call is a separate action with a small
+``delay_after`` — they must never be batched into one multi-entity call.
 """
 
-# ============================================================
-# VACATION MODE STEPS (Leaving)
-# ============================================================
-VACATION_STEPS = [
-    {
-        "alias": "Turn Off Water Heater",
-        "icon": "fas fa-fire",
-        "actions": [
-            {
-                "action": "climate/set_preset_mode",
-                "data": {
-                    "entity_id": "climate.econet_hpwh",
-                    "preset_mode": "Off",
-                },
-                "description": "Setting water heater to Off",
-            },
-        ],
-    },
-    {
-        "alias": "Set Hot Tub to Vacation Mode",
-        "icon": "fas fa-hot-tub-person",
-        "actions": [
-            {
-                "action": "climate/set_preset_mode",
-                "data": {
-                    "entity_id": "climate.hot_tub_heater",
-                    "preset_mode": "Away From Home",
-                },
-                "description": "Setting hot tub to Away From Home",
-            },
-        ],
-    },
-    {
-        "alias": "Heat Pump Vacation Setup",
-        "icon": "fas fa-temperature-arrow-down",
-        "actions": [
-            {
-                "action": "switch/turn_off",
-                "data": {
-                    "entity_id": "switch.aeco_1988_hot_tank_outdoor_reset",
-                },
-                "description": "Disabling outdoor reset",
-                "delay_after": 2,
-            },
-            {
-                "action": "number/set_value",
-                "data": {
-                    "entity_id": "number.aeco_1988_hot_tank_target_temperature",
-                    "value": "28",
-                },
-                "description": "Setting target temperature to 28°C",
-                "verify_delay": 10,
-            },
-            {
-                "action": "number/set_value",
-                "data": {
-                    "entity_id": "number.aeco_1988_backup_differential",
-                    "value": "8",
-                },
-                "description": "Setting backup differential to 8°C",
-                "verify_delay": 10,
-            },
-        ],
-    },
-    {
-        "alias": "Set Thermostats to 13.5°C",
-        "icon": "fas fa-snowflake",
-        "actions": [
-            {
-                "action": "climate/set_temperature",
-                "data": {
-                    "entity_id": "climate.master_bedroom",
-                    "temperature": 13.5,
-                    "hvac_mode": "heat",
-                },
-                "description": "Master Bedroom → 13.5°C",
-                "delay_after": 1,
-            },
-            {
-                "action": "climate/set_temperature",
-                "data": {
-                    "entity_id": "climate.basement_bunk_rooms",
-                    "temperature": 13.5,
-                    "hvac_mode": "heat",
-                },
-                "description": "Basement Bunk Rooms → 13.5°C",
-                "delay_after": 1,
-            },
-            {
-                "action": "climate/set_temperature",
-                "data": {
-                    "entity_id": "climate.main_floor",
-                    "temperature": 13.5,
-                    "hvac_mode": "heat",
-                },
-                "description": "Main Floor → 13.5°C",
-                "delay_after": 1,
-            },
-            {
-                "action": "climate/set_temperature",
-                "data": {
-                    "entity_id": "climate.basement_master",
-                    "temperature": 13.5,
-                    "hvac_mode": "heat",
-                },
-                "description": "Basement Master → 13.5°C",
-                "delay_after": 1,
-            },
-            {
-                "action": "climate/set_temperature",
-                "data": {
-                    "entity_id": "climate.ski_room",
-                    "temperature": 13.5,
-                    "hvac_mode": "heat",
-                },
-                "description": "Ski Room → 13.5°C",
-            },
-        ],
-    },
-    {
-        "alias": "Set Garage Heaters to 5°C",
-        "icon": "fas fa-warehouse",
-        "actions": [
-            {
-                "action": "climate/set_temperature",
-                "data": {
-                    "entity_id": "climate.garage_thermostat_thermostat",
-                    "temperature": 5,
-                },
-                "description": "Garage → 5°C",
-                "delay_after": 1,
-            },
-            {
-                "action": "climate/set_temperature",
-                "data": {
-                    "entity_id": "climate.storage_room_thermostat_thermostat",
-                    "temperature": 5,
-                },
-                "description": "Storage Room → 5°C",
-            },
-        ],
-    },
-    {
-        "alias": "Set Fridge & Freezer to Vacation Mode",
-        "icon": "fas fa-icicles",
-        "actions": [
-            {
-                "action": "switch/turn_on",
-                "data": {
-                    "entity_id": "switch.freezer_eco_mode",
-                },
-                "description": "Enabling freezer eco mode",
-            },
-            {
-                "action": "switch/turn_off",
-                "data": {
-                    "entity_id": "switch.freezer_dispenser",
-                },
-                "description": "Disabling freezer dispenser",
-            },
-            {
-                "action": "switch/turn_on",
-                "data": {
-                    "entity_id": "switch.refrigerator_eco_mode",
-                },
-                "description": "Enabling fridge eco mode",
-            },
-        ],
-    },
-    {
-        "alias": "Turn Off Televisions & Sonos",
-        "icon": "fas fa-tv",
-        "actions": [
-            {
-                "action": "switch/turn_off",
-                "data": {
-                    "entity_id": "switch.living_room_tv_socket_1",
-                },
-                "description": "Living Room TV",
-            },
-            {
-                "action": "switch/turn_off",
-                "data": {
-                    "entity_id": "switch.living_room_tv_socket_2",
-                },
-                "description": "Living Room Sonos",
-                "delay_after": 1,
-            },
-            {
-                "action": "switch/turn_off",
-                "data": {
-                    "entity_id": "switch.basement_master_tv_socket_1",
-                },
-                "description": "Basement Master TV",
-            },
-            {
-                "action": "switch/turn_off",
-                "data": {
-                    "entity_id": "switch.media_room_tv_socket_1",
-                },
-                "description": "Games Room TV",
-            },
-            {
-                "action": "switch/turn_off",
-                "data": {
-                    "entity_id": "switch.media_room_tv_socket_2",
-                },
-                "description": "Games Room Sonos",
-                "delay_after": 1,
-            },
-            {
-                "action": "switch/turn_off",
-                "data": {
-                    "entity_id": "switch.office_tv_socket_1",
-                },
-                "description": "Office TV",
-            },
-            {
-                "action": "switch/turn_off",
-                "data": {
-                    "entity_id": "switch.office_tv_socket_2",
-                },
-                "description": "Office Sonos",
-                "delay_after": 1,
-            },
-            {
-                "action": "switch/turn_off",
-                "data": {
-                    "entity_id": "switch.master_bedroom_tv_socket_1",
-                },
-                "description": "Master Bedroom TV",
-            },
-            {
-                "action": "switch/turn_off",
-                "data": {
-                    "entity_id": "switch.master_bedroom_tv_socket_2",
-                },
-                "description": "Master Bedroom Sonos",
-            },
-        ],
-    },
-    {
-        "alias": "Turn Off Patio Heaters",
-        "icon": "fas fa-fire-flame-curved",
-        "actions": [
-            {
-                "action": "switch/turn_off",
-                "data": {
-                    "entity_id": "switch.patio_deck_heaters",
-                },
-                "description": "Turning off patio deck heaters",
-            },
-        ],
-    },
-    {
-        "alias": "Turn Off Fireplaces",
-        "icon": "fas fa-fire",
-        "actions": [
-            {
-                "action": "climate/set_hvac_mode",
-                "data": {
-                    "entity_id": "climate.master_bedroom_2",
-                    "hvac_mode": "off",
-                },
-                "description": "Master Bedroom fireplace heater → off",
-                "delay_after": 1,
-            },
-            {
-                "action": "switch/turn_off",
-                "data": {
-                    "entity_id": "switch.master_bedroom",
-                },
-                "description": "Master Bedroom fireplace flames → off",
-                "delay_after": 1,
-            },
-            {
-                "action": "climate/set_hvac_mode",
-                "data": {
-                    "entity_id": "climate.living_room_fireplace",
-                    "hvac_mode": "off",
-                },
-                "description": "Living Room fireplace heater → off",
-                "delay_after": 1,
-            },
-            {
-                "action": "switch/turn_off",
-                "data": {
-                    "entity_id": "switch.living_room_fireplace",
-                },
-                "description": "Living Room fireplace flames → off",
-            },
-        ],
-    },
-    {
-        "alias": "Enable Home Away Mode",
-        "icon": "fas fa-plane-departure",
-        "actions": [
-            {
-                "action": "input_boolean/turn_on",
-                "data": {
-                    "entity_id": "input_boolean.home_away_mode_enabled",
-                },
-                "description": "Enabling away mode flag",
-            },
-        ],
-    },
+SEASON_HEATING = "heating"
+SEASON_COOLING = "cooling"
+
+# Zone thermostats (Nest — rate limited, set one at a time with a delay).
+ZONE_THERMOSTATS = [
+    ("climate.master_bedroom", "Master Bedroom"),
+    ("climate.basement_bunk_rooms", "Basement Bunk Rooms"),
+    ("climate.main_floor", "Main Floor"),
+    ("climate.basement_master", "Basement Master"),
+    ("climate.ski_room", "Ski Room"),
 ]
 
-# ============================================================
-# HOME MODE STEPS (Arriving)
-# ============================================================
-HOME_STEPS = [
-    {
-        "alias": "Start Water Heater",
-        "icon": "fas fa-fire",
-        "actions": [
-            {
-                "action": "climate/set_preset_mode",
-                "data": {
-                    "entity_id": "climate.econet_hpwh",
-                    "preset_mode": "Eco Mode",
-                },
-                "description": "Setting water heater to Eco Mode",
-            },
-        ],
+# Per-season zone air setpoints (°C).
+#   heating: warm the house; ski room a touch cooler.
+#   cooling: single comfort/setback target for all zones.
+ZONE_SETPOINTS = {
+    SEASON_HEATING: {
+        "home": {"climate.ski_room": 19, "_default": 20},
+        "away": {"_default": 13.5},
     },
-    {
-        "alias": "Start Hot Tub",
-        "icon": "fas fa-hot-tub-person",
-        "actions": [
-            {
-                "action": "climate/set_preset_mode",
-                "data": {
-                    "entity_id": "climate.hot_tub_heater",
-                    "preset_mode": "Standard",
-                },
-                "description": "Setting hot tub to Standard mode",
-            },
-        ],
+    SEASON_COOLING: {
+        "home": {"_default": 22},
+        "away": {"_default": 28},
     },
-    {
-        "alias": "Heat Pump Home Setup",
-        "icon": "fas fa-temperature-arrow-up",
-        "actions": [
-            {
-                "action": "number/set_value",
-                "data": {
-                    "entity_id": "number.aeco_1988_hot_tank_min_temperature",
-                    "value": "27",
+}
+
+# AECO changeover switches.
+_HEAT_DEMAND = "switch.aeco_1988_permanent_heat_demand"
+_COOL_DEMAND = "switch.aeco_1988_permanent_cool_demand"
+
+# Seconds to wait after flipping the changeover before writing tank entities.
+MODE_SWITCH_DELAY = 10
+
+
+def _zone_setpoint(season, occupancy, entity_id):
+    """Resolve the air setpoint for a zone under a season/occupancy."""
+    table = ZONE_SETPOINTS[season][occupancy]
+    return table.get(entity_id, table["_default"])
+
+
+def _mode_changeover_actions(season):
+    """
+    Actions that flip the AECO changeover to the desired season.
+
+    Turns the unwanted permanent-demand switch OFF first, then the desired one
+    ON, then waits MODE_SWITCH_DELAY so the (previously unavailable) tank
+    entities become writable.
+    """
+    if season == SEASON_COOLING:
+        off_sw, on_sw, label = _HEAT_DEMAND, _COOL_DEMAND, "cooling"
+    else:
+        off_sw, on_sw, label = _COOL_DEMAND, _HEAT_DEMAND, "heating"
+
+    return [
+        {
+            "action": "switch/turn_off",
+            "data": {"entity_id": off_sw},
+            "description": f"Clearing opposite demand (→ {label})",
+            "delay_after": 1,
+        },
+        {
+            "action": "switch/turn_on",
+            "data": {"entity_id": on_sw},
+            "description": f"Setting system to {label.upper()} mode",
+            "delay_after": MODE_SWITCH_DELAY,
+        },
+    ]
+
+
+def _heatpump_setup_step(season, occupancy):
+    """Build the 'Heat Pump Setup' step for a season/occupancy."""
+    actions = _mode_changeover_actions(season)
+
+    if season == SEASON_HEATING:
+        icon = "fas fa-fire"
+        alias = "Heat Pump Setup — Heating"
+        if occupancy == "home":
+            actions += [
+                {
+                    "action": "switch/turn_on",
+                    "data": {"entity_id": "switch.aeco_1988_hot_tank_outdoor_reset"},
+                    "description": "Enabling outdoor reset",
+                    "delay_after": 2,
                 },
-                "description": "Setting min temperature to 27°C",
-                "verify_delay": 10,
-            },
-            {
-                "action": "number/set_value",
-                "data": {
-                    "entity_id": "number.aeco_1988_hot_tank_max_temperature",
-                    "value": "38",
+                {
+                    "action": "number/set_value",
+                    "data": {
+                        "entity_id": "number.aeco_1988_hot_tank_outdoor_reset",
+                        "value": "-20",
+                    },
+                    "description": "Setting outdoor reset to -20°C",
+                    "verify_delay": 10,
                 },
-                "description": "Setting max temperature to 38°C",
-                "verify_delay": 10,
-            },
-            {
-                "action": "number/set_value",
-                "data": {
-                    "entity_id": "number.aeco_1988_hot_tank_outdoor_reset",
-                    "value": "-20",
+                {
+                    "action": "number/set_value",
+                    "data": {
+                        "entity_id": "number.aeco_1988_hot_tank_min_temperature",
+                        "value": "27",
+                    },
+                    "description": "Setting hot tank min to 27°C",
+                    "verify_delay": 10,
                 },
-                "description": "Setting outdoor reset to -20°C",
-                "verify_delay": 10,
-            },
-            {
-                "action": "switch/turn_on",
-                "data": {
-                    "entity_id": "switch.aeco_1988_hot_tank_outdoor_reset",
+                {
+                    "action": "number/set_value",
+                    "data": {
+                        "entity_id": "number.aeco_1988_hot_tank_max_temperature",
+                        "value": "38",
+                    },
+                    "description": "Setting hot tank max to 38°C",
+                    "verify_delay": 10,
                 },
-                "description": "Enabling outdoor reset",
+            ]
+        else:  # away
+            actions += [
+                {
+                    "action": "switch/turn_off",
+                    "data": {"entity_id": "switch.aeco_1988_hot_tank_outdoor_reset"},
+                    "description": "Disabling outdoor reset",
+                    "delay_after": 2,
+                },
+                {
+                    "action": "number/set_value",
+                    "data": {
+                        "entity_id": "number.aeco_1988_hot_tank_target_temperature",
+                        "value": "28",
+                    },
+                    "description": "Setting hot tank target to 28°C",
+                    "verify_delay": 10,
+                },
+                {
+                    "action": "number/set_value",
+                    "data": {
+                        "entity_id": "number.aeco_1988_backup_differential",
+                        "value": "8",
+                    },
+                    "description": "Setting backup differential to 8°C",
+                    "verify_delay": 10,
+                },
+            ]
+    else:  # cooling
+        icon = "fas fa-snowflake"
+        alias = "Heat Pump Setup — Cooling"
+        if occupancy == "home":
+            cold_target, cold_min, cold_max = "12", "10", "18"
+        else:  # away
+            cold_target, cold_min, cold_max = "18", "14", "20"
+        actions += [
+            {
+                "action": "switch/turn_off",
+                "data": {"entity_id": "switch.aeco_1988_cold_tank_outdoor_reset"},
+                "description": "Disabling cold tank outdoor reset",
                 "delay_after": 2,
             },
-        ],
-    },
-    {
-        "alias": "Set Thermostats to Home Temperatures",
-        "icon": "fas fa-house-chimney",
-        "actions": [
+            {
+                "action": "number/set_value",
+                "data": {
+                    "entity_id": "number.aeco_1988_cold_tank_target_temperature",
+                    "value": cold_target,
+                },
+                "description": f"Setting cold tank target to {cold_target}°C",
+                "verify_delay": 10,
+            },
+            {
+                "action": "number/set_value",
+                "data": {
+                    "entity_id": "number.aeco_1988_cold_tank_min_temperature",
+                    "value": cold_min,
+                },
+                "description": f"Setting cold tank min to {cold_min}°C",
+                "verify_delay": 10,
+            },
+            {
+                "action": "number/set_value",
+                "data": {
+                    "entity_id": "number.aeco_1988_cold_tank_max_temperature",
+                    "value": cold_max,
+                },
+                "description": f"Setting cold tank max to {cold_max}°C",
+                "verify_delay": 10,
+            },
+        ]
+
+    return {"alias": alias, "icon": icon, "actions": actions}
+
+
+def _thermostats_step(season, occupancy, alias, icon, clear_presets=False, extra_actions=None):
+    """
+    Build a thermostat step. Nest units are rate-limited, so each zone is a
+    separate action with a delay. Optionally clears presets first (home mode)
+    and appends extra actions (e.g. garage/storage on arrival).
+    """
+    hvac_mode = "cool" if season == SEASON_COOLING else "heat"
+    actions = []
+
+    if clear_presets:
+        actions.append(
             {
                 "action": "climate/set_preset_mode",
                 "data": {
-                    "entity_id": [
-                        "climate.master_bedroom",
-                        "climate.basement_bunk_rooms",
-                        "climate.main_floor",
-                        "climate.basement_master",
-                        "climate.ski_room",
-                    ],
+                    "entity_id": [e for e, _ in ZONE_THERMOSTATS],
                     "preset_mode": "none",
                 },
                 "description": "Clearing presets on all thermostats",
                 "delay_after": 2,
-            },
+            }
+        )
+
+    for entity_id, name in ZONE_THERMOSTATS:
+        temp = _zone_setpoint(season, occupancy, entity_id)
+        actions.append(
             {
                 "action": "climate/set_temperature",
                 "data": {
-                    "entity_id": "climate.master_bedroom",
-                    "temperature": 20,
-                    "hvac_mode": "heat",
+                    "entity_id": entity_id,
+                    "temperature": temp,
+                    "hvac_mode": hvac_mode,
                 },
-                "description": "Master Bedroom → 20°C",
+                "description": f"{name} → {temp}°C ({hvac_mode})",
                 "delay_after": 1,
-            },
-            {
-                "action": "climate/set_temperature",
-                "data": {
-                    "entity_id": "climate.basement_bunk_rooms",
-                    "temperature": 20,
-                    "hvac_mode": "heat",
+            }
+        )
+
+    if extra_actions:
+        actions.extend(extra_actions)
+
+    return {"alias": alias, "icon": icon, "actions": actions}
+
+
+# ============================================================
+# SEASON-INDEPENDENT STEPS
+# ============================================================
+def _vacation_static_prefix():
+    return [
+        {
+            "alias": "Turn Off Water Heater",
+            "icon": "fas fa-fire",
+            "actions": [
+                {
+                    "action": "climate/set_preset_mode",
+                    "data": {
+                        "entity_id": "climate.econet_hpwh",
+                        "preset_mode": "Off",
+                    },
+                    "description": "Setting water heater to Off",
                 },
-                "description": "Basement Bunk Rooms → 20°C",
-                "delay_after": 1,
-            },
-            {
-                "action": "climate/set_temperature",
-                "data": {
-                    "entity_id": "climate.main_floor",
-                    "temperature": 20,
-                    "hvac_mode": "heat",
+            ],
+        },
+        {
+            "alias": "Set Hot Tub to Vacation Mode",
+            "icon": "fas fa-hot-tub-person",
+            "actions": [
+                {
+                    "action": "climate/set_preset_mode",
+                    "data": {
+                        "entity_id": "climate.hot_tub_heater",
+                        "preset_mode": "Away From Home",
+                    },
+                    "description": "Setting hot tub to Away From Home",
                 },
-                "description": "Main Floor → 20°C",
-                "delay_after": 1,
-            },
-            {
-                "action": "climate/set_temperature",
-                "data": {
-                    "entity_id": "climate.basement_master",
-                    "temperature": 20,
-                    "hvac_mode": "heat",
+            ],
+        },
+    ]
+
+
+def _vacation_static_suffix():
+    return [
+        {
+            "alias": "Set Garage Heaters to 5°C",
+            "icon": "fas fa-warehouse",
+            "actions": [
+                {
+                    "action": "climate/set_temperature",
+                    "data": {
+                        "entity_id": "climate.garage_thermostat_thermostat",
+                        "temperature": 5,
+                    },
+                    "description": "Garage → 5°C",
+                    "delay_after": 1,
                 },
-                "description": "Basement Master → 20°C",
-                "delay_after": 1,
-            },
-            {
-                "action": "climate/set_temperature",
-                "data": {
-                    "entity_id": "climate.ski_room",
-                    "temperature": 19,
-                    "hvac_mode": "heat",
+                {
+                    "action": "climate/set_temperature",
+                    "data": {
+                        "entity_id": "climate.storage_room_thermostat_thermostat",
+                        "temperature": 5,
+                    },
+                    "description": "Storage Room → 5°C",
                 },
-                "description": "Ski Room → 19°C",
-                "delay_after": 1,
-            },
-            {
-                "action": "climate/set_temperature",
-                "data": {
-                    "entity_id": "climate.garage_thermostat_thermostat",
-                    "temperature": 10,
+            ],
+        },
+        {
+            "alias": "Set Fridge & Freezer to Vacation Mode",
+            "icon": "fas fa-icicles",
+            "actions": [
+                {
+                    "action": "switch/turn_on",
+                    "data": {"entity_id": "switch.freezer_eco_mode"},
+                    "description": "Enabling freezer eco mode",
                 },
-                "description": "Garage → 10°C",
-                "delay_after": 1,
-            },
-            {
-                "action": "climate/set_temperature",
-                "data": {
-                    "entity_id": "climate.storage_room_thermostat_thermostat",
-                    "temperature": 10,
+                {
+                    "action": "switch/turn_off",
+                    "data": {"entity_id": "switch.freezer_dispenser"},
+                    "description": "Disabling freezer dispenser",
                 },
-                "description": "Storage Room → 10°C",
-            },
-        ],
+                {
+                    "action": "switch/turn_on",
+                    "data": {"entity_id": "switch.refrigerator_eco_mode"},
+                    "description": "Enabling fridge eco mode",
+                },
+            ],
+        },
+        {
+            "alias": "Turn Off Televisions & Sonos",
+            "icon": "fas fa-tv",
+            "actions": [
+                {
+                    "action": "switch/turn_off",
+                    "data": {"entity_id": "switch.living_room_tv_socket_1"},
+                    "description": "Living Room TV",
+                },
+                {
+                    "action": "switch/turn_off",
+                    "data": {"entity_id": "switch.living_room_tv_socket_2"},
+                    "description": "Living Room Sonos",
+                    "delay_after": 1,
+                },
+                {
+                    "action": "switch/turn_off",
+                    "data": {"entity_id": "switch.basement_master_tv_socket_1"},
+                    "description": "Basement Master TV",
+                },
+                {
+                    "action": "switch/turn_off",
+                    "data": {"entity_id": "switch.media_room_tv_socket_1"},
+                    "description": "Games Room TV",
+                },
+                {
+                    "action": "switch/turn_off",
+                    "data": {"entity_id": "switch.media_room_tv_socket_2"},
+                    "description": "Games Room Sonos",
+                    "delay_after": 1,
+                },
+                {
+                    "action": "switch/turn_off",
+                    "data": {"entity_id": "switch.office_tv_socket_1"},
+                    "description": "Office TV",
+                },
+                {
+                    "action": "switch/turn_off",
+                    "data": {"entity_id": "switch.office_tv_socket_2"},
+                    "description": "Office Sonos",
+                    "delay_after": 1,
+                },
+                {
+                    "action": "switch/turn_off",
+                    "data": {"entity_id": "switch.master_bedroom_tv_socket_1"},
+                    "description": "Master Bedroom TV",
+                },
+                {
+                    "action": "switch/turn_off",
+                    "data": {"entity_id": "switch.master_bedroom_tv_socket_2"},
+                    "description": "Master Bedroom Sonos",
+                },
+            ],
+        },
+        {
+            "alias": "Turn Off Patio Heaters",
+            "icon": "fas fa-fire-flame-curved",
+            "actions": [
+                {
+                    "action": "switch/turn_off",
+                    "data": {"entity_id": "switch.patio_deck_heaters"},
+                    "description": "Turning off patio deck heaters",
+                },
+            ],
+        },
+        {
+            "alias": "Turn Off Fireplaces",
+            "icon": "fas fa-fire",
+            "actions": [
+                {
+                    "action": "climate/set_hvac_mode",
+                    "data": {
+                        "entity_id": "climate.master_bedroom_2",
+                        "hvac_mode": "off",
+                    },
+                    "description": "Master Bedroom fireplace heater → off",
+                    "delay_after": 1,
+                },
+                {
+                    "action": "switch/turn_off",
+                    "data": {"entity_id": "switch.master_bedroom"},
+                    "description": "Master Bedroom fireplace flames → off",
+                    "delay_after": 1,
+                },
+                {
+                    "action": "climate/set_hvac_mode",
+                    "data": {
+                        "entity_id": "climate.living_room_fireplace",
+                        "hvac_mode": "off",
+                    },
+                    "description": "Living Room fireplace heater → off",
+                    "delay_after": 1,
+                },
+                {
+                    "action": "switch/turn_off",
+                    "data": {"entity_id": "switch.living_room_fireplace"},
+                    "description": "Living Room fireplace flames → off",
+                },
+            ],
+        },
+        {
+            "alias": "Enable Home Away Mode",
+            "icon": "fas fa-plane-departure",
+            "actions": [
+                {
+                    "action": "input_boolean/turn_on",
+                    "data": {"entity_id": "input_boolean.home_away_mode_enabled"},
+                    "description": "Enabling away mode flag",
+                },
+            ],
+        },
+    ]
+
+
+def _home_static_prefix():
+    return [
+        {
+            "alias": "Start Water Heater",
+            "icon": "fas fa-fire",
+            "actions": [
+                {
+                    "action": "climate/set_preset_mode",
+                    "data": {
+                        "entity_id": "climate.econet_hpwh",
+                        "preset_mode": "Eco Mode",
+                    },
+                    "description": "Setting water heater to Eco Mode",
+                },
+            ],
+        },
+        {
+            "alias": "Start Hot Tub",
+            "icon": "fas fa-hot-tub-person",
+            "actions": [
+                {
+                    "action": "climate/set_preset_mode",
+                    "data": {
+                        "entity_id": "climate.hot_tub_heater",
+                        "preset_mode": "Standard",
+                    },
+                    "description": "Setting hot tub to Standard mode",
+                },
+            ],
+        },
+    ]
+
+
+def _home_static_suffix():
+    return [
+        {
+            "alias": "Setup Fridge/Freezer for Arrival",
+            "icon": "fas fa-icicles",
+            "actions": [
+                {
+                    "action": "switch/turn_off",
+                    "data": {"entity_id": "switch.freezer_eco_mode"},
+                    "description": "Disabling freezer eco mode",
+                },
+                {
+                    "action": "switch/turn_on",
+                    "data": {"entity_id": "switch.freezer_dispenser"},
+                    "description": "Enabling freezer dispenser",
+                },
+                {
+                    "action": "switch/turn_off",
+                    "data": {"entity_id": "switch.refrigerator_eco_mode"},
+                    "description": "Disabling fridge eco mode",
+                },
+            ],
+        },
+        {
+            "alias": "Turn On Televisions & Sonos",
+            "icon": "fas fa-tv",
+            "actions": [
+                {
+                    "action": "switch/turn_on",
+                    "data": {"entity_id": "switch.living_room_tv_socket_1"},
+                    "description": "Living Room TV",
+                },
+                {
+                    "action": "switch/turn_on",
+                    "data": {"entity_id": "switch.living_room_tv_socket_2"},
+                    "description": "Living Room Sonos",
+                    "delay_after": 1,
+                },
+                {
+                    "action": "switch/turn_on",
+                    "data": {"entity_id": "switch.basement_master_tv_socket_1"},
+                    "description": "Basement Master TV",
+                },
+                {
+                    "action": "switch/turn_on",
+                    "data": {"entity_id": "switch.media_room_tv_socket_1"},
+                    "description": "Games Room TV",
+                },
+                {
+                    "action": "switch/turn_on",
+                    "data": {"entity_id": "switch.media_room_tv_socket_2"},
+                    "description": "Games Room Sonos",
+                    "delay_after": 1,
+                },
+                {
+                    "action": "switch/turn_on",
+                    "data": {"entity_id": "switch.office_tv_socket_1"},
+                    "description": "Office TV",
+                },
+                {
+                    "action": "switch/turn_on",
+                    "data": {"entity_id": "switch.office_tv_socket_2"},
+                    "description": "Office Sonos",
+                    "delay_after": 1,
+                },
+                {
+                    "action": "switch/turn_on",
+                    "data": {"entity_id": "switch.master_bedroom_tv_socket_1"},
+                    "description": "Master Bedroom TV",
+                },
+                {
+                    "action": "switch/turn_on",
+                    "data": {"entity_id": "switch.master_bedroom_tv_socket_2"},
+                    "description": "Master Bedroom Sonos",
+                },
+            ],
+        },
+        {
+            "alias": "Disable Home Away Mode",
+            "icon": "fas fa-house-flag",
+            "actions": [
+                {
+                    "action": "input_boolean/turn_off",
+                    "data": {"entity_id": "input_boolean.home_away_mode_enabled"},
+                    "description": "Disabling away mode flag",
+                },
+            ],
+        },
+    ]
+
+
+# Garage/storage heaters are heat-only; they stay set to their heating values
+# in both seasons (in cooling season they simply never call). Appended to the
+# arrival thermostat step.
+_HOME_GARAGE_ACTIONS = [
+    {
+        "action": "climate/set_temperature",
+        "data": {
+            "entity_id": "climate.garage_thermostat_thermostat",
+            "temperature": 10,
+        },
+        "description": "Garage → 10°C",
+        "delay_after": 1,
     },
     {
-        "alias": "Setup Fridge/Freezer for Arrival",
-        "icon": "fas fa-icicles",
-        "actions": [
-            {
-                "action": "switch/turn_off",
-                "data": {
-                    "entity_id": "switch.freezer_eco_mode",
-                },
-                "description": "Disabling freezer eco mode",
-            },
-            {
-                "action": "switch/turn_on",
-                "data": {
-                    "entity_id": "switch.freezer_dispenser",
-                },
-                "description": "Enabling freezer dispenser",
-            },
-            {
-                "action": "switch/turn_off",
-                "data": {
-                    "entity_id": "switch.refrigerator_eco_mode",
-                },
-                "description": "Disabling fridge eco mode",
-            },
-        ],
-    },
-    {
-        "alias": "Turn On Televisions & Sonos",
-        "icon": "fas fa-tv",
-        "actions": [
-            {
-                "action": "switch/turn_on",
-                "data": {
-                    "entity_id": "switch.living_room_tv_socket_1",
-                },
-                "description": "Living Room TV",
-            },
-            {
-                "action": "switch/turn_on",
-                "data": {
-                    "entity_id": "switch.living_room_tv_socket_2",
-                },
-                "description": "Living Room Sonos",
-                "delay_after": 1,
-            },
-            {
-                "action": "switch/turn_on",
-                "data": {
-                    "entity_id": "switch.basement_master_tv_socket_1",
-                },
-                "description": "Basement Master TV",
-            },
-            {
-                "action": "switch/turn_on",
-                "data": {
-                    "entity_id": "switch.media_room_tv_socket_1",
-                },
-                "description": "Games Room TV",
-            },
-            {
-                "action": "switch/turn_on",
-                "data": {
-                    "entity_id": "switch.media_room_tv_socket_2",
-                },
-                "description": "Games Room Sonos",
-                "delay_after": 1,
-            },
-            {
-                "action": "switch/turn_on",
-                "data": {
-                    "entity_id": "switch.office_tv_socket_1",
-                },
-                "description": "Office TV",
-            },
-            {
-                "action": "switch/turn_on",
-                "data": {
-                    "entity_id": "switch.office_tv_socket_2",
-                },
-                "description": "Office Sonos",
-                "delay_after": 1,
-            },
-            {
-                "action": "switch/turn_on",
-                "data": {
-                    "entity_id": "switch.master_bedroom_tv_socket_1",
-                },
-                "description": "Master Bedroom TV",
-            },
-            {
-                "action": "switch/turn_on",
-                "data": {
-                    "entity_id": "switch.master_bedroom_tv_socket_2",
-                },
-                "description": "Master Bedroom Sonos",
-            },
-        ],
-    },
-    {
-        "alias": "Disable Home Away Mode",
-        "icon": "fas fa-house-flag",
-        "actions": [
-            {
-                "action": "input_boolean/turn_off",
-                "data": {
-                    "entity_id": "input_boolean.home_away_mode_enabled",
-                },
-                "description": "Disabling away mode flag",
-            },
-        ],
+        "action": "climate/set_temperature",
+        "data": {
+            "entity_id": "climate.storage_room_thermostat_thermostat",
+            "temperature": 10,
+        },
+        "description": "Storage Room → 10°C",
     },
 ]
+
+
+# ============================================================
+# BUILDERS
+# ============================================================
+def build_vacation_steps(season=SEASON_HEATING):
+    """Steps to put the lodge into vacation (away) mode for the given season."""
+    thermo_alias = (
+        "Set Thermostats to Away Cool (28°C)"
+        if season == SEASON_COOLING
+        else "Set Thermostats to Away Heat (13.5°C)"
+    )
+    thermo_icon = "fas fa-snowflake" if season == SEASON_COOLING else "fas fa-temperature-arrow-down"
+    return (
+        _vacation_static_prefix()
+        + [
+            _heatpump_setup_step(season, "away"),
+            _thermostats_step(season, "away", thermo_alias, thermo_icon),
+        ]
+        + _vacation_static_suffix()
+    )
+
+
+def build_home_steps(season=SEASON_HEATING):
+    """Steps to prepare the lodge for arrival (home) for the given season."""
+    if season == SEASON_COOLING:
+        thermo_alias = "Set Thermostats to Home Cool (22°C)"
+        thermo_icon = "fas fa-snowflake"
+    else:
+        thermo_alias = "Set Thermostats to Home Heat (20°C)"
+        thermo_icon = "fas fa-house-chimney"
+    return (
+        _home_static_prefix()
+        + [
+            _heatpump_setup_step(season, "home"),
+            _thermostats_step(
+                season,
+                "home",
+                thermo_alias,
+                thermo_icon,
+                clear_presets=True,
+                extra_actions=_HOME_GARAGE_ACTIONS,
+            ),
+        ]
+        + _home_static_suffix()
+    )
+
+
+# Backward-compatible module-level constants (default = heating variant).
+VACATION_STEPS = build_vacation_steps(SEASON_HEATING)
+HOME_STEPS = build_home_steps(SEASON_HEATING)

--- a/vacation_mode/templates/vacation_mode.html
+++ b/vacation_mode/templates/vacation_mode.html
@@ -46,6 +46,25 @@
         color: #fff;
     }
 
+    .season-badge {
+        display: inline-block;
+        margin-left: 8px;
+        padding: 4px 14px;
+        border-radius: 20px;
+        font-size: 13px;
+        font-weight: 600;
+    }
+
+    .season-badge.cooling {
+        background-color: #0d6efd;
+        color: #fff;
+    }
+
+    .season-badge.heating {
+        background-color: #fd7e14;
+        color: #fff;
+    }
+
     .controls-row {
         display: flex;
         flex-direction: column;
@@ -378,6 +397,16 @@
                 <i class="fas fa-plane"></i> Away Mode Active
             {% else %}
                 <i class="fas fa-house"></i> Home Mode Active
+            {% endif %}
+        </div>
+        <div id="season-badge" class="season-badge {% if season_is_cooling %}cooling{% else %}heating{% endif %}">
+            {% if season_is_cooling %}
+                <i class="fas fa-snowflake"></i> Cooling Season
+            {% else %}
+                <i class="fas fa-fire"></i> Heating Season
+            {% endif %}
+            {% if season_avg is not None %}
+                <span style="opacity: 0.85;">&middot; outdoor avg {{ season_avg|floatformat:1 }}&deg;C</span>
             {% endif %}
         </div>
     </div>

--- a/vacation_mode/tests.py
+++ b/vacation_mode/tests.py
@@ -30,6 +30,7 @@ from .executor import (
     call_ha_service,
     execute_step,
     get_away_mode_state,
+    get_current_season,
     start_execution,
     get_run_status,
     get_active_run,
@@ -46,8 +47,16 @@ from .executor import (
     STATUS_FAILED,
     MAX_RETRIES,
     RETRY_DELAY,
+    SEASON_THRESHOLD_C,
 )
-from .steps import VACATION_STEPS, HOME_STEPS
+from .steps import (
+    VACATION_STEPS,
+    HOME_STEPS,
+    SEASON_HEATING,
+    SEASON_COOLING,
+    build_vacation_steps,
+    build_home_steps,
+)
 
 
 class GetAwayModeStateTests(TestCase):
@@ -471,6 +480,12 @@ class ViewTests(TestCase):
 
     def setUp(self):
         self.client = Client()
+        p = patch(
+            "vacation_mode.views.get_current_season",
+            return_value=("heating", 5.0),
+        )
+        self.mock_season = p.start()
+        self.addCleanup(p.stop)
 
     @patch("vacation_mode.views.get_away_mode_state")
     @patch("vacation_mode.views.get_active_run")
@@ -806,6 +821,13 @@ class StartExecutionTests(TestCase):
         if _execution_lock.locked():
             _execution_lock.release()
         _runs.clear()
+        # Avoid a live HA call for the season decision.
+        p = patch(
+            "vacation_mode.executor.get_current_season",
+            return_value=("heating", 5.0),
+        )
+        self.mock_season = p.start()
+        self.addCleanup(p.stop)
 
     def tearDown(self):
         # Wait for any background threads to finish
@@ -866,6 +888,12 @@ class AdditionalViewTests(TestCase):
 
     def setUp(self):
         self.client = Client()
+        p = patch(
+            "vacation_mode.views.get_current_season",
+            return_value=("heating", 5.0),
+        )
+        self.mock_season = p.start()
+        self.addCleanup(p.stop)
 
     def test_execute_get_not_allowed(self):
         """Execute endpoint should reject GET requests."""
@@ -972,6 +1000,14 @@ class AdditionalViewTests(TestCase):
 
 class TemplateRenderTests(TestCase):
     """Tests for template rendering correctness."""
+
+    def setUp(self):
+        p = patch(
+            "vacation_mode.views.get_current_season",
+            return_value=("heating", 5.0),
+        )
+        self.mock_season = p.start()
+        self.addCleanup(p.stop)
 
     @patch("vacation_mode.views.get_away_mode_state")
     @patch("vacation_mode.views.get_active_run")
@@ -1090,10 +1126,14 @@ class SeleniumVacationModeTests(StaticLiveServerTestCase):
         from vacation_mode import views as vm_views
         self._original_get_away_mode_state = vm_views.get_away_mode_state
         vm_views.get_away_mode_state = lambda: False
+        # Avoid a live HA call for the season decision
+        self._original_get_current_season = vm_views.get_current_season
+        vm_views.get_current_season = lambda: ("heating", 5.0)
 
     def tearDown(self):
         from vacation_mode import views as vm_views
         vm_views.get_away_mode_state = self._original_get_away_mode_state
+        vm_views.get_current_season = self._original_get_current_season
 
     def _set_away_state(self, is_away):
         from vacation_mode import views as vm_views
@@ -1189,3 +1229,294 @@ class SeleniumVacationModeTests(StaticLiveServerTestCase):
             EC.presence_of_element_located((By.ID, "dry-run-checkbox"))
         )
         self.assertFalse(checkbox.is_selected())
+
+
+def _all_actions(steps):
+    """Flatten every action across a list of steps."""
+    actions = []
+    for step in steps:
+        actions.extend(step["actions"])
+    return actions
+
+
+def _entity_ids(steps):
+    """Collect every entity_id referenced across a list of steps (flattened)."""
+    ids = set()
+    for action in _all_actions(steps):
+        ent = action.get("data", {}).get("entity_id")
+        if isinstance(ent, list):
+            ids.update(ent)
+        elif ent:
+            ids.add(ent)
+    return ids
+
+
+class GetCurrentSeasonTests(TestCase):
+    """Tests for executor.get_current_season season selection."""
+
+    def _mock_response(self, status_code=200, state="20.0"):
+        resp = MagicMock()
+        resp.status_code = status_code
+        resp.json.return_value = {"state": state}
+        return resp
+
+    @patch("vacation_mode.executor.requests.get")
+    def test_warm_avg_selects_cooling(self, mock_get):
+        mock_get.return_value = self._mock_response(state="20.0")
+        season, avg = get_current_season()
+        self.assertEqual(season, SEASON_COOLING)
+        self.assertEqual(avg, 20.0)
+
+    @patch("vacation_mode.executor.requests.get")
+    def test_cold_avg_selects_heating(self, mock_get):
+        mock_get.return_value = self._mock_response(state="5.0")
+        season, avg = get_current_season()
+        self.assertEqual(season, SEASON_HEATING)
+        self.assertEqual(avg, 5.0)
+
+    @patch("vacation_mode.executor.requests.get")
+    def test_threshold_boundary_selects_cooling(self, mock_get):
+        """At exactly the threshold we cool (>= threshold)."""
+        mock_get.return_value = self._mock_response(state=str(SEASON_THRESHOLD_C))
+        season, avg = get_current_season()
+        self.assertEqual(season, SEASON_COOLING)
+        self.assertEqual(avg, SEASON_THRESHOLD_C)
+
+    @patch("vacation_mode.executor.requests.get")
+    def test_just_below_threshold_selects_heating(self, mock_get):
+        mock_get.return_value = self._mock_response(state=str(SEASON_THRESHOLD_C - 0.1))
+        season, _ = get_current_season()
+        self.assertEqual(season, SEASON_HEATING)
+
+    @patch("vacation_mode.executor.requests.get")
+    def test_http_error_defaults_to_heating(self, mock_get):
+        mock_get.return_value = self._mock_response(status_code=500)
+        season, avg = get_current_season()
+        self.assertEqual(season, SEASON_HEATING)
+        self.assertIsNone(avg)
+
+    @patch("vacation_mode.executor.requests.get")
+    def test_unparseable_state_defaults_to_heating(self, mock_get):
+        mock_get.return_value = self._mock_response(state="unavailable")
+        season, avg = get_current_season()
+        self.assertEqual(season, SEASON_HEATING)
+        self.assertIsNone(avg)
+
+    @patch("vacation_mode.executor.requests.get")
+    def test_request_exception_defaults_to_heating(self, mock_get):
+        mock_get.side_effect = requests_lib.RequestException("boom")
+        season, avg = get_current_season()
+        self.assertEqual(season, SEASON_HEATING)
+        self.assertIsNone(avg)
+
+
+class SeasonStepBuilderTests(TestCase):
+    """Tests for the season-aware step builders in steps.py."""
+
+    def test_heating_builders_match_module_defaults(self):
+        """Module-level constants must equal the heating variant (back-compat)."""
+        self.assertEqual(build_vacation_steps(SEASON_HEATING), VACATION_STEPS)
+        self.assertEqual(build_home_steps(SEASON_HEATING), HOME_STEPS)
+
+    def test_step_counts_match_across_seasons(self):
+        """Cooling must yield the same step count as heating (test invariant)."""
+        self.assertEqual(
+            len(build_vacation_steps(SEASON_COOLING)),
+            len(build_vacation_steps(SEASON_HEATING)),
+        )
+        self.assertEqual(
+            len(build_home_steps(SEASON_COOLING)),
+            len(build_home_steps(SEASON_HEATING)),
+        )
+
+    def test_vacation_step_count_is_ten(self):
+        self.assertEqual(len(build_vacation_steps(SEASON_HEATING)), 10)
+
+    def test_home_step_count_is_seven(self):
+        self.assertEqual(len(build_home_steps(SEASON_HEATING)), 7)
+
+    def test_heating_writes_hot_tank_not_cold(self):
+        ids = _entity_ids(build_vacation_steps(SEASON_HEATING))
+        self.assertTrue(any("hot_tank" in e for e in ids))
+        self.assertFalse(any("cold_tank" in e for e in ids))
+
+    def test_cooling_writes_cold_tank_not_hot(self):
+        ids = _entity_ids(build_vacation_steps(SEASON_COOLING))
+        self.assertTrue(any("cold_tank" in e for e in ids))
+        self.assertFalse(any("hot_tank" in e for e in ids))
+
+    def test_heating_sets_permanent_heat_demand_on(self):
+        actions = _all_actions(build_vacation_steps(SEASON_HEATING))
+        on_heat = [
+            a for a in actions
+            if a["action"] == "switch/turn_on"
+            and a["data"].get("entity_id") == "switch.aeco_1988_permanent_heat_demand"
+        ]
+        off_cool = [
+            a for a in actions
+            if a["action"] == "switch/turn_off"
+            and a["data"].get("entity_id") == "switch.aeco_1988_permanent_cool_demand"
+        ]
+        self.assertEqual(len(on_heat), 1)
+        self.assertEqual(len(off_cool), 1)
+
+    def test_cooling_sets_permanent_cool_demand_on(self):
+        actions = _all_actions(build_vacation_steps(SEASON_COOLING))
+        on_cool = [
+            a for a in actions
+            if a["action"] == "switch/turn_on"
+            and a["data"].get("entity_id") == "switch.aeco_1988_permanent_cool_demand"
+        ]
+        off_heat = [
+            a for a in actions
+            if a["action"] == "switch/turn_off"
+            and a["data"].get("entity_id") == "switch.aeco_1988_permanent_heat_demand"
+        ]
+        self.assertEqual(len(on_cool), 1)
+        self.assertEqual(len(off_heat), 1)
+
+    def test_changeover_precedes_tank_writes(self):
+        """The demand-on switch must be flipped before any tank number write."""
+        for season, tank in (
+            (SEASON_HEATING, "hot_tank"),
+            (SEASON_COOLING, "cold_tank"),
+        ):
+            steps = build_vacation_steps(season)
+            # find the heat-pump setup step (has the changeover switches)
+            hp_step = next(
+                s for s in steps
+                if any(
+                    "permanent_" in a["data"].get("entity_id", "")
+                    for a in s["actions"]
+                )
+            )
+            demand_on = "permanent_cool_demand" if season == SEASON_COOLING else "permanent_heat_demand"
+            actions = hp_step["actions"]
+            on_idx = next(
+                i for i, a in enumerate(actions)
+                if a["action"] == "switch/turn_on"
+                and demand_on in a["data"].get("entity_id", "")
+            )
+            tank_idx = next(
+                i for i, a in enumerate(actions)
+                if tank in a["data"].get("entity_id", "")
+            )
+            self.assertLess(on_idx, tank_idx, f"{season}: changeover must precede tank write")
+
+    def test_changeover_settle_delay(self):
+        """The demand-on flip must wait MODE_SWITCH_DELAY before tank writes."""
+        from vacation_mode.steps import MODE_SWITCH_DELAY
+        actions = _all_actions(build_vacation_steps(SEASON_COOLING))
+        on_cool = next(
+            a for a in actions
+            if a["action"] == "switch/turn_on"
+            and a["data"].get("entity_id") == "switch.aeco_1988_permanent_cool_demand"
+        )
+        self.assertEqual(on_cool.get("delay_after"), MODE_SWITCH_DELAY)
+
+    def test_cooling_thermostats_use_cool_mode(self):
+        actions = _all_actions(build_vacation_steps(SEASON_COOLING))
+        set_temp = [a for a in actions if a["action"] == "climate/set_temperature"
+                    and a["data"].get("entity_id", "").startswith("climate.")
+                    and "hvac_mode" in a["data"]]
+        self.assertTrue(set_temp)
+        self.assertTrue(all(a["data"]["hvac_mode"] == "cool" for a in set_temp))
+
+    def test_heating_thermostats_use_heat_mode(self):
+        actions = _all_actions(build_vacation_steps(SEASON_HEATING))
+        set_temp = [a for a in actions if a["action"] == "climate/set_temperature"
+                    and "hvac_mode" in a["data"]]
+        self.assertTrue(set_temp)
+        self.assertTrue(all(a["data"]["hvac_mode"] == "heat" for a in set_temp))
+
+    def test_cooling_away_thermostat_setpoint(self):
+        """Away/cooling zones target 28°C."""
+        actions = _all_actions(build_vacation_steps(SEASON_COOLING))
+        zone_sets = [
+            a for a in actions
+            if a["action"] == "climate/set_temperature"
+            and a["data"].get("hvac_mode") == "cool"
+        ]
+        self.assertTrue(zone_sets)
+        self.assertTrue(all(a["data"]["temperature"] == 28 for a in zone_sets))
+
+    def test_cooling_home_thermostat_setpoint(self):
+        """Home/cooling zones target 22°C."""
+        actions = _all_actions(build_home_steps(SEASON_COOLING))
+        zone_sets = [
+            a for a in actions
+            if a["action"] == "climate/set_temperature"
+            and a["data"].get("hvac_mode") == "cool"
+        ]
+        self.assertTrue(zone_sets)
+        self.assertTrue(all(a["data"]["temperature"] == 22 for a in zone_sets))
+
+    def test_nest_thermostats_set_individually(self):
+        """Each Nest zone is its own action (rate-limited, never batched)."""
+        actions = _all_actions(build_vacation_steps(SEASON_COOLING))
+        zone_sets = [
+            a for a in actions
+            if a["action"] == "climate/set_temperature"
+            and a["data"].get("hvac_mode") == "cool"
+        ]
+        for a in zone_sets:
+            self.assertNotIsInstance(
+                a["data"]["entity_id"], list,
+                "Nest thermostats must be set one entity at a time",
+            )
+
+    def test_cooling_home_cold_tank_values(self):
+        actions = _all_actions(build_home_steps(SEASON_COOLING))
+        by_ent = {
+            a["data"]["entity_id"]: a["data"]["value"]
+            for a in actions if a["action"] == "number/set_value"
+        }
+        self.assertEqual(by_ent["number.aeco_1988_cold_tank_target_temperature"], "12")
+        self.assertEqual(by_ent["number.aeco_1988_cold_tank_min_temperature"], "10")
+        self.assertEqual(by_ent["number.aeco_1988_cold_tank_max_temperature"], "18")
+
+    def test_cooling_away_cold_tank_values(self):
+        actions = _all_actions(build_vacation_steps(SEASON_COOLING))
+        by_ent = {
+            a["data"]["entity_id"]: a["data"]["value"]
+            for a in actions if a["action"] == "number/set_value"
+        }
+        self.assertEqual(by_ent["number.aeco_1988_cold_tank_target_temperature"], "18")
+        self.assertEqual(by_ent["number.aeco_1988_cold_tank_min_temperature"], "14")
+        self.assertEqual(by_ent["number.aeco_1988_cold_tank_max_temperature"], "20")
+
+
+class StartExecutionSeasonTests(TestCase):
+    """start_execution should record and honour the detected season."""
+
+    def setUp(self):
+        if _execution_lock.locked():
+            _execution_lock.release()
+        _runs.clear()
+
+    def tearDown(self):
+        time.sleep(0.2)
+        if _execution_lock.locked():
+            _execution_lock.release()
+        _runs.clear()
+
+    @patch("vacation_mode.executor.call_ha_service")
+    @patch("vacation_mode.executor.get_current_season", return_value=("cooling", 22.0))
+    def test_cooling_season_stored_and_builds_cooling_steps(self, mock_season, mock_call):
+        mock_call.return_value = (True, None)
+        run_id, error = start_execution("vacation", dry_run=True)
+        self.assertIsNone(error)
+        self.assertEqual(_runs[run_id]["season"], "cooling")
+        self.assertEqual(_runs[run_id]["season_avg"], 22.0)
+        aliases = [s["alias"] for s in _runs[run_id]["steps"]]
+        self.assertIn("Heat Pump Setup — Cooling", aliases)
+
+    @patch("vacation_mode.executor.call_ha_service")
+    @patch("vacation_mode.executor.get_current_season", return_value=("heating", 3.0))
+    def test_heating_season_stored_and_builds_heating_steps(self, mock_season, mock_call):
+        mock_call.return_value = (True, None)
+        run_id, error = start_execution("home", dry_run=True)
+        self.assertIsNone(error)
+        self.assertEqual(_runs[run_id]["season"], "heating")
+        aliases = [s["alias"] for s in _runs[run_id]["steps"]]
+        self.assertIn("Heat Pump Setup — Heating", aliases)

--- a/vacation_mode/views.py
+++ b/vacation_mode/views.py
@@ -3,8 +3,14 @@ from django.shortcuts import render
 from django.views.decorators.http import require_POST, require_GET
 import json
 
-from .executor import get_away_mode_state, start_execution, get_run_status, get_active_run
-from .steps import VACATION_STEPS, HOME_STEPS
+from .executor import (
+    get_away_mode_state,
+    get_current_season,
+    start_execution,
+    get_run_status,
+    get_active_run,
+)
+from .steps import build_vacation_steps, build_home_steps, SEASON_COOLING
 
 
 def vacation_mode_view(request):
@@ -18,10 +24,16 @@ def vacation_mode_view(request):
         mode = active_run["mode"]
         steps = active_run["steps"]
         run_id = active_run["run_id"]
+        season = active_run.get("season")
+        season_avg = active_run.get("season_avg")
     else:
-        # Show the steps for the action they'd take next
+        # Show the steps for the action they'd take next, for the season the
+        # system would pick right now.
+        season, season_avg = get_current_season()
         mode = "home" if is_away else "vacation"
-        steps_def = HOME_STEPS if is_away else VACATION_STEPS
+        steps_def = (
+            build_home_steps(season) if is_away else build_vacation_steps(season)
+        )
         steps = [
             {"alias": s["alias"], "icon": s["icon"], "status": "pending", "attempt": 0, "error": None, "progress": None}
             for s in steps_def
@@ -34,6 +46,9 @@ def vacation_mode_view(request):
         "steps": json.dumps(steps),
         "run_id": run_id,
         "active_run": active_run is not None,
+        "season": season,
+        "season_is_cooling": season == SEASON_COOLING,
+        "season_avg": season_avg,
     }
     return render(request, "vacation_mode.html", context)
 


### PR DESCRIPTION
## Summary
Adds **seasonal heating/cooling** support to the `vacation_mode` app, which previously assumed heating for every HVAC step. At the Sun Peaks lodge the **AECO-1988** is a changeover heat pump: its mode is set by the mutually-exclusive `permanent_heat_demand` / `permanent_cool_demand` switches, and heating vs cooling write different tank entities (hot vs cold) and thermostat modes.

The season is chosen automatically at run time from the daily-average outdoor temperature (`sensor.hvac_load_shift_metrics_outdoor_avg_day`): **>= 15 degC -> cooling**, else heating. On any read error it defaults to **heating** (freeze-safe).

## Changes
- **steps.py** - static `VACATION_STEPS` / `HOME_STEPS` replaced by `build_vacation_steps(season)` / `build_home_steps(season)`. The AECO changeover (clear opposite demand, set desired demand, 10 s settle) is folded into the heat-pump setup step so **step counts are unchanged** (10 vacation / 7 home). Nest thermostats are set **one at a time** with a delay (they are rate-limited). Module-level constants keep the heating variant for back-compat.
- **executor.py** - `get_current_season()` reads the outdoor-avg sensor; `start_execution` builds season-specific steps and records `season` / `season_avg` on the run.
- **views.py + template** - a season badge shows the detected mode + outdoor avg.
- **tests.py** - patched the new season dependency; added `GetCurrentSeasonTests`, `SeasonStepBuilderTests`, `StartExecutionSeasonTests`.
- **settings_test.py** - sqlite override so the suite runs without a Postgres server.

## Settings matrix
| | Away | Home |
|---|---|---|
| **Heating** | outdoor reset off, hot tank target 28, backup diff 8, zones 13.5 (unchanged) | outdoor reset on/-20, hot tank 27/38, zones 20 (ski 19), garage 10 (unchanged) |
| **Cooling** | cold tank 18/14/20, zones cool 28, garage 5 | cold tank 12/10/18, zones cool 22, garage 10 |

## Testing
`python manage.py test vacation_mode --settings=BlackDiamondHub.settings_test --exclude-tag=selenium` -> **115 passed**.
Also validated the step builders standalone (step counts, tank entities per season, changeover-before-tank-write ordering, cool/heat mode + setpoints, Nest one-at-a-time).

Selenium tests not run (no browser/driver in this environment).