### PR TITLE
vacation_mode: fixed cold-tank target in cooling (drop unavailable min/max)

### DIFF
--- a/vacation_mode/steps.py
+++ b/vacation_mode/steps.py
@@ -174,10 +174,12 @@ def _heatpump_setup_step(season, occupancy):
     else:  # cooling
         icon = "fas fa-snowflake"
         alias = "Heat Pump Setup — Cooling"
-        if occupancy == "home":
-            cold_target, cold_min, cold_max = "12", "10", "18"
-        else:  # away
-            cold_target, cold_min, cold_max = "18", "14", "20"
+        # Fixed cold-tank target: outdoor reset OFF so the tank holds a constant
+        # chilled-water temperature. The min/max entities only exist while
+        # outdoor reset is ON (they bound the reset curve), so we do NOT write
+        # them here — at a target this warm (12°C) a reset curve adds no value,
+        # and the dew-point mixer valve protects the floor.
+        cold_target = "12" if occupancy == "home" else "18"
         actions += [
             {
                 "action": "switch/turn_off",
@@ -192,24 +194,6 @@ def _heatpump_setup_step(season, occupancy):
                     "value": cold_target,
                 },
                 "description": f"Setting cold tank target to {cold_target}°C",
-                "verify_delay": 10,
-            },
-            {
-                "action": "number/set_value",
-                "data": {
-                    "entity_id": "number.aeco_1988_cold_tank_min_temperature",
-                    "value": cold_min,
-                },
-                "description": f"Setting cold tank min to {cold_min}°C",
-                "verify_delay": 10,
-            },
-            {
-                "action": "number/set_value",
-                "data": {
-                    "entity_id": "number.aeco_1988_cold_tank_max_temperature",
-                    "value": cold_max,
-                },
-                "description": f"Setting cold tank max to {cold_max}°C",
                 "verify_delay": 10,
             },
         ]

--- a/vacation_mode/tests.py
+++ b/vacation_mode/tests.py
@@ -1472,8 +1472,10 @@ class SeasonStepBuilderTests(TestCase):
             for a in actions if a["action"] == "number/set_value"
         }
         self.assertEqual(by_ent["number.aeco_1988_cold_tank_target_temperature"], "12")
-        self.assertEqual(by_ent["number.aeco_1988_cold_tank_min_temperature"], "10")
-        self.assertEqual(by_ent["number.aeco_1988_cold_tank_max_temperature"], "18")
+        # Fixed target only: min/max are unavailable while reset is off, so we
+        # must NOT attempt to write them.
+        self.assertNotIn("number.aeco_1988_cold_tank_min_temperature", by_ent)
+        self.assertNotIn("number.aeco_1988_cold_tank_max_temperature", by_ent)
 
     def test_cooling_away_cold_tank_values(self):
         actions = _all_actions(build_vacation_steps(SEASON_COOLING))
@@ -1482,8 +1484,25 @@ class SeasonStepBuilderTests(TestCase):
             for a in actions if a["action"] == "number/set_value"
         }
         self.assertEqual(by_ent["number.aeco_1988_cold_tank_target_temperature"], "18")
-        self.assertEqual(by_ent["number.aeco_1988_cold_tank_min_temperature"], "14")
-        self.assertEqual(by_ent["number.aeco_1988_cold_tank_max_temperature"], "20")
+        self.assertNotIn("number.aeco_1988_cold_tank_min_temperature", by_ent)
+        self.assertNotIn("number.aeco_1988_cold_tank_max_temperature", by_ent)
+
+    def test_cooling_leaves_reset_off_no_minmax(self):
+        """Cooling holds a fixed target: reset off and no min/max writes."""
+        for build in (build_home_steps, build_vacation_steps):
+            actions = _all_actions(build(SEASON_COOLING))
+            reset_off = [
+                a for a in actions
+                if a["action"] == "switch/turn_off"
+                and a["data"].get("entity_id") == "switch.aeco_1988_cold_tank_outdoor_reset"
+            ]
+            self.assertEqual(len(reset_off), 1)
+            minmax = [
+                a for a in actions
+                if a["action"] == "number/set_value"
+                and a["data"].get("entity_id", "").endswith(("cold_tank_min_temperature", "cold_tank_max_temperature"))
+            ]
+            self.assertEqual(minmax, [])
 
 
 class StartExecutionSeasonTests(TestCase):


### PR DESCRIPTION
## Summary
Follow-up fix to #94. When testing **Activate** in cooling season, the cold-tank **min/max** writes failed every time with `unavailable`.

**Root cause:** the cooling heat-pump step turns `switch.aeco_1988_cold_tank_outdoor_reset` **off** (to hold a fixed target), but the `cold_tank_min_temperature` / `cold_tank_max_temperature` number entities **only exist while outdoor reset is ON** (they bound the reset curve). With reset off they read `unavailable`, so those two `number/set_value` actions failed on all retries. Confirmed live on the AECO:
\\\
cold_tank_outdoor_reset       = off
cold_tank_target_temperature  = 12.2   (writable)
cold_tank_min_temperature     = unavailable
cold_tank_max_temperature     = unavailable
\\\

## Fix
Cooling now writes **only** `cold_tank_target` (12 °C home / 18 °C away) with outdoor reset off — a fixed chilled-water target. Dropped the min/max writes. At a target this warm a reset curve adds no value, and the dew-point mixer valve protects the floor. This mirrors the working **heating-away** pattern (reset off + fixed target).

## Tests
Updated `test_cooling_home_cold_tank_values` / `test_cooling_away_cold_tank_values` to assert no min/max writes, plus a new `test_cooling_leaves_reset_off_no_minmax`.
`manage.py test vacation_mode --settings=BlackDiamondHub.settings_test --exclude-tag=selenium` -> **116 passed**.

Everything else in the live Activate run worked (changeover to cooling, cold target 12, all zones cool 22, garages, fridge/freezer, TVs, away flag). The only other failure was the hot tub (`unavailable` — known receiver issue, expected).