### PR TITLE
vacation_mode: raise home cooling target to 14.4C (12C never satisfies)

### DIFF
--- a/vacation_mode/steps.py
+++ b/vacation_mode/steps.py
@@ -177,9 +177,14 @@ def _heatpump_setup_step(season, occupancy):
         # Fixed cold-tank target: outdoor reset OFF so the tank holds a constant
         # chilled-water temperature. The min/max entities only exist while
         # outdoor reset is ON (they bound the reset curve), so we do NOT write
-        # them here — at a target this warm (12°C) a reset curve adds no value,
-        # and the dew-point mixer valve protects the floor.
-        cold_target = "12" if occupancy == "home" else "18"
+        # them here — a reset curve adds no value at these warm targets, and the
+        # dew-point mixer valve protects the floor.
+        #
+        # The target must stay >= 13.5°C: the AECO clears cooling demand only
+        # once the tank reaches target - 1.5°C, but the heat pump's own floor is
+        # 12°C, so a target of 12 could never satisfy (demand would never clear).
+        # 14.4 (the system's original home setpoint) shuts off at ~12.9°C.
+        cold_target = "14.4" if occupancy == "home" else "18"
         actions += [
             {
                 "action": "switch/turn_off",

--- a/vacation_mode/tests.py
+++ b/vacation_mode/tests.py
@@ -1471,7 +1471,7 @@ class SeasonStepBuilderTests(TestCase):
             a["data"]["entity_id"]: a["data"]["value"]
             for a in actions if a["action"] == "number/set_value"
         }
-        self.assertEqual(by_ent["number.aeco_1988_cold_tank_target_temperature"], "12")
+        self.assertEqual(by_ent["number.aeco_1988_cold_tank_target_temperature"], "14.4")
         # Fixed target only: min/max are unavailable while reset is off, so we
         # must NOT attempt to write them.
         self.assertNotIn("number.aeco_1988_cold_tank_min_temperature", by_ent)


### PR DESCRIPTION
## Summary
Follow-up to #94/#95. A home-cooling `cold_tank_target` of **12 °C** can never satisfy the AECO cooling demand and would run the heat pump indefinitely.

**Why:** the AECO clears cooling demand only once the tank reaches `target − 1.5 °C` (its differential), i.e. **10.5 °C** at a 12 °C target. But the heat pump's own low-limit setpoint is **12 °C**, so the tank never gets that cold → demand never clears.

**Constraint:** `target − 1.5 ≥ 12` → **target ≥ 13.5 °C**.

## Fix
Revert home cooling to the system's original **14.4 °C** setpoint (shuts off at ~12.9 °C, comfortable margin). Away (18 °C) was already safe. The live setpoint has already been reverted to 14.4 on the AECO.

## Tests
Updated `test_cooling_home_cold_tank_values` to expect 14.4. `manage.py test vacation_mode --settings=BlackDiamondHub.settings_test --exclude-tag=selenium` -> **116 passed**.